### PR TITLE
feat-auth: 인증 및 권한 관리 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,13 +28,37 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
 
+
+
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
+
+    //security
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    testImplementation 'org.springframework.security:spring-security-test'
+
+    //validation
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+    // AWS S3
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+
+    //jwt
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+    //redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+    //web-client
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
 
     annotationProcessor 'org.projectlombok:lombok'
+
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/src/main/java/com/ktb/ktb_cj_community_spring_be/auth/config/SecurityConfig.java
+++ b/src/main/java/com/ktb/ktb_cj_community_spring_be/auth/config/SecurityConfig.java
@@ -1,0 +1,91 @@
+package com.ktb.ktb_cj_community_spring_be.auth.config;
+
+import static org.springframework.http.HttpMethod.DELETE;
+import static org.springframework.http.HttpMethod.POST;
+import static org.springframework.http.HttpMethod.PUT;
+import static org.springframework.security.web.util.matcher.AntPathRequestMatcher.antMatcher;
+
+import com.ktb.ktb_cj_community_spring_be.global.util.jwt.JwtAccessDeniedHandler;
+import com.ktb.ktb_cj_community_spring_be.global.util.jwt.JwtAuthenticationEntryPoint;
+import com.ktb.ktb_cj_community_spring_be.global.util.jwt.JwtAuthenticationFilter;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.util.matcher.RequestMatcher;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+      private final JwtAuthenticationFilter jwtAuthenticationFilter;
+      private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+      private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
+
+      @Bean
+      public PasswordEncoder passwordEncoder() {
+            return new BCryptPasswordEncoder();
+      }
+
+      @Bean
+      public SecurityFilterChain filterChain(HttpSecurity httpSecurity) throws Exception {
+            httpSecurity
+                    .csrf(AbstractHttpConfigurer::disable)
+                    .formLogin(AbstractHttpConfigurer::disable)
+                    .httpBasic(AbstractHttpConfigurer::disable)
+                    .sessionManagement((sessionManagement) ->
+                            sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                    )
+                    .authorizeHttpRequests(
+                            auth -> auth
+                                    .requestMatchers(requestHasRoleUser()).hasRole("USER")
+                                    .requestMatchers(requestHasAnyRoleUserAdmin())
+                                    .hasAnyRole("USER", "ADMIN")
+                                    .anyRequest().permitAll()
+                    ).exceptionHandling(configurer -> {
+                          configurer.authenticationEntryPoint(jwtAuthenticationEntryPoint);
+                          configurer.accessDeniedHandler(jwtAccessDeniedHandler);
+                    })
+                    .addFilterBefore(jwtAuthenticationFilter,
+                            UsernamePasswordAuthenticationFilter.class);
+
+            return httpSecurity.build();
+      }
+
+      private RequestMatcher[] requestHasRoleUser() {
+            List<RequestMatcher> requestMatchers = List.of(
+                    antMatcher("/api/user"),
+                    antMatcher(POST, "/api/post"),
+                    antMatcher(PUT, "/api/post"),
+                    antMatcher(DELETE, "/api/post"),
+                    antMatcher(POST, "/api/post/like"),
+                    antMatcher(POST, "/api/post/unlike"),
+                    antMatcher(POST, "/api/comment"),
+                    antMatcher(PUT, "/api/comment")
+            );
+            return requestMatchers.toArray(RequestMatcher[]::new);
+      }
+
+      private RequestMatcher[] requestHasRoleAdmin() {
+
+            return null;
+      }
+
+      private RequestMatcher[] requestHasAnyRoleUserAdmin() {
+
+            List<RequestMatcher> requestMatchers = List.of(
+                    antMatcher("/api/comment")
+            );
+            return requestMatchers.toArray(RequestMatcher[]::new);
+      }
+}
+

--- a/src/main/java/com/ktb/ktb_cj_community_spring_be/auth/dto/LogoutDto.java
+++ b/src/main/java/com/ktb/ktb_cj_community_spring_be/auth/dto/LogoutDto.java
@@ -1,0 +1,19 @@
+package com.ktb.ktb_cj_community_spring_be.auth.dto;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class LogoutDto {
+
+      private String accessToken;
+
+}

--- a/src/main/java/com/ktb/ktb_cj_community_spring_be/auth/dto/ReissueDto.java
+++ b/src/main/java/com/ktb/ktb_cj_community_spring_be/auth/dto/ReissueDto.java
@@ -1,0 +1,24 @@
+package com.ktb.ktb_cj_community_spring_be.auth.dto;
+
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReissueDto {
+
+      @NotBlank(message = "Access token 은 필수 입력 항목입니다.")
+      private String accessToken;
+
+      @NotBlank(message = "Refresh token 은 필수 입력 항목입니다.")
+      private String refreshToken;
+
+}

--- a/src/main/java/com/ktb/ktb_cj_community_spring_be/auth/dto/SignInDto.java
+++ b/src/main/java/com/ktb/ktb_cj_community_spring_be/auth/dto/SignInDto.java
@@ -1,0 +1,24 @@
+package com.ktb.ktb_cj_community_spring_be.auth.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SignInDto {
+
+      @Email
+      private String email;
+
+      @NotBlank
+      private String password;
+
+}

--- a/src/main/java/com/ktb/ktb_cj_community_spring_be/auth/dto/SignUpDto.java
+++ b/src/main/java/com/ktb/ktb_cj_community_spring_be/auth/dto/SignUpDto.java
@@ -1,0 +1,55 @@
+package com.ktb.ktb_cj_community_spring_be.auth.dto;
+
+import com.ktb.ktb_cj_community_spring_be.member.entity.Member;
+import com.ktb.ktb_cj_community_spring_be.member.entity.type.MemberRoleType;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class SignUpDto {
+
+      @Email
+      private String email;
+
+      @NotBlank
+      private String password;
+
+      @NotBlank
+      @Size(max = 10)
+      private String nickname;
+
+      @NotBlank
+      private String phoneNumber;
+
+      private String profileImageUrl;
+
+      public static SignUpDto fromEntity(Member member) {
+            return SignUpDto.builder()
+                    .email(member.getEmail())
+                    .password(member.getPassword())
+                    .nickname(member.getNickname())
+                    .profileImageUrl(member.getProfileImageUrl())
+                    .build();
+      }
+
+      public static Member signUpForm(SignUpDto request, String encodedPasswordEncoder) {
+            return Member.builder()
+                    .email(request.getEmail())
+                    .password(encodedPasswordEncoder)
+                    .nickname(request.getNickname())
+                    .roleType(MemberRoleType.USER)
+                    .build();
+      }
+
+}

--- a/src/main/java/com/ktb/ktb_cj_community_spring_be/auth/service/AuthService.java
+++ b/src/main/java/com/ktb/ktb_cj_community_spring_be/auth/service/AuthService.java
@@ -1,0 +1,21 @@
+package com.ktb.ktb_cj_community_spring_be.auth.service;
+
+import com.ktb.ktb_cj_community_spring_be.auth.dto.LogoutDto;
+import com.ktb.ktb_cj_community_spring_be.auth.dto.ReissueDto;
+import com.ktb.ktb_cj_community_spring_be.auth.dto.SignInDto;
+import com.ktb.ktb_cj_community_spring_be.auth.dto.SignUpDto;
+import com.ktb.ktb_cj_community_spring_be.global.util.jwt.dto.TokenDto;
+import org.springframework.web.multipart.MultipartFile;
+
+public interface AuthService {
+
+      SignUpDto signUp(SignUpDto request, MultipartFile multipartFile);
+
+      TokenDto signIn(SignInDto request);
+
+      void logout(LogoutDto request);
+
+      TokenDto reissue(ReissueDto request);
+
+
+}

--- a/src/main/java/com/ktb/ktb_cj_community_spring_be/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/ktb/ktb_cj_community_spring_be/auth/service/AuthServiceImpl.java
@@ -1,0 +1,178 @@
+package com.ktb.ktb_cj_community_spring_be.auth.service;
+
+import static com.ktb.ktb_cj_community_spring_be.global.exception.type.ErrorCode.*;
+
+import com.ktb.ktb_cj_community_spring_be.auth.dto.LogoutDto;
+import com.ktb.ktb_cj_community_spring_be.auth.dto.ReissueDto;
+import com.ktb.ktb_cj_community_spring_be.auth.dto.SignInDto;
+import com.ktb.ktb_cj_community_spring_be.auth.dto.SignUpDto;
+import com.ktb.ktb_cj_community_spring_be.global.exception.GlobalException;
+import com.ktb.ktb_cj_community_spring_be.global.service.RedisService;
+import com.ktb.ktb_cj_community_spring_be.global.util.aws.service.AwsS3Service;
+import com.ktb.ktb_cj_community_spring_be.global.util.jwt.TokenProvider;
+import com.ktb.ktb_cj_community_spring_be.global.util.jwt.dto.TokenDto;
+import com.ktb.ktb_cj_community_spring_be.member.entity.Member;
+import com.ktb.ktb_cj_community_spring_be.member.repository.MemberRepository;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import org.springframework.web.multipart.MultipartFile;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AuthServiceImpl implements AuthService {
+
+      private final PasswordEncoder passwordEncoder;
+      private final MemberRepository memberRepository;
+
+      private final AwsS3Service awsS3Service;
+      private final TokenProvider tokenProvider;
+      private final RedisService redisService;
+
+      private static final String REFRESH_TOKEN_PREFIX = "REFRESH_TOKEN: ";
+
+      @Override
+      public SignUpDto signUp(SignUpDto request, MultipartFile profileImage) {
+            if (memberRepository.existsByEmail(request.getEmail())) {
+                  throw new GlobalException(DUPLICATE_USER);
+            }
+
+            String encodedPasswordEncoder = passwordEncoder.encode(request.getPassword());
+
+            //프로필 이미지가 제공되었을 경우 S3에 업로드하고 그 URL 을 가져옴
+            String profileImageUrl = null; // 기본값은 null
+            if (profileImage != null && !profileImageUrl.isEmpty()) {
+                  try {
+                        profileImageUrl = uploadProfileImage(profileImage);
+
+                  } catch (Exception e) { // 이미지 업로드 중 오류 발생시 예외처리
+                        throw new GlobalException(PROFILE_IMAGE_UPLOAD_ERROR);
+                  }
+            }
+
+            request.setProfileImageUrl(profileImageUrl);
+
+            Member saveMember = memberRepository.save(
+                    SignUpDto.signUpForm(request, encodedPasswordEncoder));
+
+            return SignUpDto.fromEntity(memberRepository.save(saveMember));
+      }
+
+
+      @Override
+      public TokenDto signIn(SignInDto request) {
+            Member member = memberRepository.findByEmail(request.getEmail())
+                    .orElseThrow(() -> new GlobalException(USER_NOT_FOUND));
+
+            if (!passwordEncoder.matches(request.getPassword(), member.getPassword())) {
+                  throw new GlobalException(PASSWORD_NOT_MATCH);
+            }
+
+            return generateToken(member.getEmail(), member.getRoleType().getCode());
+      }
+
+
+      /**
+       * 사용자의 로그아웃 요청 처리
+       *
+       * @param request 로그아웃을 요청한 사용자의 accessToken 정보를 담은 객체
+       */
+      @Override
+      public void logout(LogoutDto request) {
+
+            // 제공된 엑세스 토큰의 유효성 검증.
+            if (!tokenProvider.validateToken(request.getAccessToken())) {
+                  throw new GlobalException(INVALID_TOKEN);
+            }
+
+            // 토큰이 유효하다면, Redis 에서 해당 토큰 정보를 삭제.
+            if (redisService.getData(REFRESH_TOKEN_PREFIX + request.getAccessToken()) != null) {
+                  redisService.deleteData(REFRESH_TOKEN_PREFIX + request.getAccessToken());
+            }
+
+            // 엑세스 토큰의 유효 시간을 확인하고 로그아웃한 토큰을 블랙리스트에 등록.
+            Long expiredTime = tokenProvider.getExpireTime(request.getAccessToken());
+            redisService.setDataExpire(REFRESH_TOKEN_PREFIX + request.getAccessToken(),
+                    "LOGOUT", expiredTime);
+
+
+      }
+
+
+      /**
+       * 기존의 토큰이 유효하지 않아, 새로운 토큰을 발행하는 경우에 사용
+       *
+       * @param request 새로운 토큰을 발행하기 위한 정보를 담고 있는 객체
+       * @return 새로 발행된 토큰 정보를 담은 TokenDto 객체
+       */
+      @Override
+      public TokenDto reissue(ReissueDto request) {
+
+            // Redis 에서 기존의 엑세스 토큰을 키로 가지는 데이터를 가져욤.
+            String data = redisService.getData(REFRESH_TOKEN_PREFIX + request.getAccessToken());
+
+            // 저장된 데이터(value)가 없거나, 저장된 Refresh 토큰과 요청된 Refresh 토큰이 일치하지 않으면 예외 발생.
+            if (!StringUtils.hasText(data) || !data.equals(request.getRefreshToken())) {
+                  throw new GlobalException(INVALID_TOKEN);
+            }
+
+            // 엑세스 토큰을 이용해 사용자의 인증 정보를 가져옴
+            Authentication authentication = tokenProvider.getAuthentication(
+                    request.getAccessToken());
+
+            // Redis 에서 기존의 엑세스 토큰 삭제
+            redisService.deleteData(REFRESH_TOKEN_PREFIX + request.getAccessToken());
+
+            return generateToken(authentication.getName(), getAuthorities(authentication));
+      }
+
+      /**
+       * JWT 토큰 생성하고, Redis 에 저장
+       *
+       * @param email          사용자 이메일
+       * @param memberRoleType 사용자 타입
+       * @return 생성된 토큰 정보를 담은 TokenDto 객체
+       */
+      private TokenDto generateToken(String email, String memberRoleType) {
+            TokenDto tokenDto = tokenProvider.generateToken(email, memberRoleType);
+
+            // 생성된 토큰을 Redis 에 저장
+            redisService.setDataExpire(REFRESH_TOKEN_PREFIX + tokenDto.getAccessToken(),
+                    tokenDto.getRefreshToken(), tokenDto.getRefreshTokenExpireTime());
+
+            return tokenDto;
+      }
+
+      /**
+       * 인증 객체에서 권한 정보를 반환
+       *
+       * @param authentication 인증 객체
+       * @return 인증 객체에서 가져온 권한 정보를 문자열로 변환하여 반환.
+       */
+      private String getAuthorities(Authentication authentication) {
+            return authentication.getAuthorities().stream()
+                    .map(GrantedAuthority::getAuthority)
+                    .collect(Collectors.joining());
+      }
+
+      /**
+       * 프로필 이미지를 AWS S3에 업로드하고, 업로드된 이미지의 URL 을 반환
+       *
+       * @param profileImage 업로드할 이미지 파일
+       * @return 업로드된 이미지의 S3 URL
+       */
+      private String uploadProfileImage(MultipartFile profileImage) {
+
+            String fileName = awsS3Service.generateFileName(profileImage);
+            awsS3Service.uploadToS3(profileImage, fileName);
+
+            return awsS3Service.getUrl(fileName);
+      }
+
+}

--- a/src/main/java/com/ktb/ktb_cj_community_spring_be/auth/web/AuthController.java
+++ b/src/main/java/com/ktb/ktb_cj_community_spring_be/auth/web/AuthController.java
@@ -1,0 +1,55 @@
+package com.ktb.ktb_cj_community_spring_be.auth.web;
+
+import com.amazonaws.Response;
+import com.ktb.ktb_cj_community_spring_be.auth.dto.LogoutDto;
+import com.ktb.ktb_cj_community_spring_be.auth.dto.ReissueDto;
+import com.ktb.ktb_cj_community_spring_be.auth.dto.SignInDto;
+import com.ktb.ktb_cj_community_spring_be.auth.dto.SignUpDto;
+import com.ktb.ktb_cj_community_spring_be.auth.service.AuthService;
+import com.ktb.ktb_cj_community_spring_be.global.util.jwt.dto.TokenDto;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/auth")
+public class AuthController {
+
+      private final AuthService authService;
+      // private final MailService mailService;
+
+
+      @PostMapping("/signup")
+      public ResponseEntity<SignUpDto> signUp(@RequestPart("request") SignUpDto request,
+              @RequestPart(name = "image", required = false) MultipartFile image) {
+            return ResponseEntity.status(HttpStatus.CREATED)
+                    .body(authService.signUp(request, image));
+      }
+
+      @PostMapping("/signIn")
+      public ResponseEntity<TokenDto> signIn(@RequestBody SignInDto request) {
+            return ResponseEntity.ok(authService.signIn(request));
+      }
+
+      @PostMapping("/logout")
+      public ResponseEntity<?> logout(@RequestBody LogoutDto request) {
+
+            return ResponseEntity.status(HttpStatus.OK).body("로그아웃 성공");
+      }
+
+      @PostMapping("/reissue")
+      public ResponseEntity<TokenDto> reissue(@Valid @RequestBody ReissueDto request) {
+
+            return ResponseEntity.ok(authService.reissue(request));
+      }
+
+
+}

--- a/src/main/java/com/ktb/ktb_cj_community_spring_be/global/config/AppConfig.java
+++ b/src/main/java/com/ktb/ktb_cj_community_spring_be/global/config/AppConfig.java
@@ -1,0 +1,28 @@
+package com.ktb.ktb_cj_community_spring_be.global.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Jackson 의 ObjectMapper 를 커스터 마이징
+ * Java 8 날짜 및 시간을 처리하여 사람이 읽을 수 있는 형식으로 직렬화
+ */
+@Configuration
+public class AppConfig {
+
+      /**
+       *  ObjectMapper 를 커스터마이징하여 Spring 컨텍스트에 빈으로 등록하는 메서드
+       * @return 커스터 마이징 된 ObjectMapper
+       */
+      @Bean
+      public ObjectMapper objectMapper(){
+            ObjectMapper objectMapper = new ObjectMapper();
+            objectMapper.registerModule(new JavaTimeModule());
+            objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+            return objectMapper;
+      }
+}

--- a/src/main/java/com/ktb/ktb_cj_community_spring_be/global/config/JpaAuditingConfig.java
+++ b/src/main/java/com/ktb/ktb_cj_community_spring_be/global/config/JpaAuditingConfig.java
@@ -1,0 +1,10 @@
+package com.ktb.ktb_cj_community_spring_be.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {
+
+}

--- a/src/main/java/com/ktb/ktb_cj_community_spring_be/global/config/RedisConfig.java
+++ b/src/main/java/com/ktb/ktb_cj_community_spring_be/global/config/RedisConfig.java
@@ -1,0 +1,72 @@
+package com.ktb.ktb_cj_community_spring_be.global.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.CacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+
+/**
+ * Redis DB 연결 설정
+ */
+@Configuration
+@RequiredArgsConstructor
+public class RedisConfig {
+
+      @Value("${spring.data.redis.host}")
+      private String host;
+
+      @Value("${spring.data.redis.port}")
+      private int port;
+
+      @Bean
+      public CacheManager redisCacheManager(RedisConnectionFactory redisConnectionFactory) {
+
+            RedisCacheConfiguration conf = RedisCacheConfiguration.defaultCacheConfig()
+                    .serializeKeysWith(RedisSerializationContext.SerializationPair
+                            .fromSerializer(new StringRedisSerializer()))
+                    .serializeValuesWith(RedisSerializationContext.SerializationPair
+                            .fromSerializer(new GenericJackson2JsonRedisSerializer()));
+
+            return RedisCacheManager.RedisCacheManagerBuilder
+                    .fromConnectionFactory(redisConnectionFactory)
+                    .cacheDefaults(conf)
+                    .build();
+      }
+
+      @Bean
+      public RedisConnectionFactory redisConnectionFactory() {
+            return new LettuceConnectionFactory(host, port);
+      }
+
+      @Bean
+      public RedisTemplate<String, Object> redisTemplate() {
+            RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+
+            // RedisTemplate 에  위에서 생성한 Redis 연결 팩토리를 설정
+            redisTemplate.setConnectionFactory(redisConnectionFactory());
+
+            // RedisTemplate 에 키와 값을 String 형ㅌ태로 직렬화/ 역직렬화
+            redisTemplate.setKeySerializer(new StringRedisSerializer());
+            redisTemplate.setValueSerializer(new StringRedisSerializer());
+
+            // RedisTemplate 에 해시키와 값을 String 형태로 직렬화/ 역직렬화
+            redisTemplate.setHashKeySerializer(new StringRedisSerializer());
+            redisTemplate.setValueSerializer(new StringRedisSerializer());
+
+            // RedisTemplate 에 기본 직렬화 도구로 설정
+            redisTemplate.setValueSerializer(new StringRedisSerializer());
+
+            return redisTemplate;
+      }
+
+}

--- a/src/main/java/com/ktb/ktb_cj_community_spring_be/global/config/WebMvcConfig.java
+++ b/src/main/java/com/ktb/ktb_cj_community_spring_be/global/config/WebMvcConfig.java
@@ -1,0 +1,11 @@
+package com.ktb.ktb_cj_community_spring_be.global.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebMvcConfig implements WebMvcConfigurer{
+
+}

--- a/src/main/java/com/ktb/ktb_cj_community_spring_be/global/exception/type/ErrorCode.java
+++ b/src/main/java/com/ktb/ktb_cj_community_spring_be/global/exception/type/ErrorCode.java
@@ -20,6 +20,8 @@ public enum ErrorCode {
       WRITE_NOT_YOURSELF(HttpStatus.BAD_REQUEST, "본인이 작성한 글만 수정 또는 삭제할 수 있습니다."),
       POST_NOT_FOUND(HttpStatus.BAD_REQUEST, "해당 글을 찾을 수 없습니다."),
       COMMENT_NOT_FOUND(HttpStatus.BAD_REQUEST, "해당 댓글을 찾을 수 없습니다."),
+      PROFILE_IMAGE_UPLOAD_ERROR(HttpStatus.BAD_REQUEST, "프로필 이미지 업로드 중 오류가 발생했습니다."),
+      POST_IMAGE_UPLOAD_ERROR(HttpStatus.BAD_REQUEST, "게시물 이미지 업로드 중 오류가 발생했습니다."),
 
 
       /**

--- a/src/main/java/com/ktb/ktb_cj_community_spring_be/global/service/RedisService.java
+++ b/src/main/java/com/ktb/ktb_cj_community_spring_be/global/service/RedisService.java
@@ -21,7 +21,7 @@ public class RedisService {
        * 주어진 Key 에 대응하는 데이터를 Redis DB 에서 조회
        *
        * @param key 조회하고자 하는 데이터의 Key
-       * @return key 에  대응하는 데이터
+       * @return key 에 대응하는 데이터
        */
       public String getData(String key) {
             ValueOperations<String, Object> valueOperations = redisTemplate.opsForValue();

--- a/src/main/java/com/ktb/ktb_cj_community_spring_be/global/service/RedisService.java
+++ b/src/main/java/com/ktb/ktb_cj_community_spring_be/global/service/RedisService.java
@@ -1,0 +1,69 @@
+package com.ktb.ktb_cj_community_spring_be.global.service;
+
+import java.time.Duration;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Service;
+
+/**
+ * Redis DB 데이터 처리
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RedisService {
+
+      private final RedisTemplate<String, Object> redisTemplate;
+
+      /**
+       * 주어진 Key 에 대응하는 데이터를 Redis DB 에서 조회
+       *
+       * @param key 조회하고자 하는 데이터의 Key
+       * @return key 에  대응하는 데이터
+       */
+      public String getData(String key) {
+            ValueOperations<String, Object> valueOperations = redisTemplate.opsForValue();
+            return (String) valueOperations.get(key);
+      }
+
+      /**
+       * 주어진 key 와 value 를 Redis DB에 저장. 저장된 데이터는 주어진 시간이 지나면 자동으로 삭제
+       *
+       * @param key         저장하고자하는 데이터의 key
+       * @param value       저장하고자하는 데이터의 value
+       * @param expiredTime 데이터의 만료 시간 (밀리초 단위)
+       */
+      public void setDataExpire(String key, String value, Long expiredTime) {
+            ValueOperations<String, Object> valueOperations = redisTemplate.opsForValue();
+            valueOperations.set(key, value, Duration.ofMillis(expiredTime));
+      }
+
+      /**
+       * 주어진 key 에 대응하는 데이터가 Redis DB에 존재하는지 확인.
+       *
+       * @param key 확인하고자 하는 데이터의 key
+       * @return 데이터 존재 여부
+       */
+      public boolean existData(String key) {
+            return Boolean.TRUE.equals(redisTemplate.hasKey(key));
+      }
+
+      /**
+       *  주어진 key 에 대등하는 데이터를 Redis DB에 삭제.
+       * @param key 삭제하고자는 데이터의 key
+       */
+      public void deleteData(String key) {
+            try {
+                  Boolean result = redisTemplate.delete(key);
+                  if (Boolean.TRUE.equals(result)) {
+                        log.info("Successfully deleted key : {}", key);
+                  } else {
+                        log.info("Failed to delete key : {}", key);
+                  }
+            } catch (Exception e) {
+                  log.error("Error occurred while deleting key : {}", key, e);
+            }
+      }
+}

--- a/src/main/java/com/ktb/ktb_cj_community_spring_be/global/util/aws/config/AwsS3Config.java
+++ b/src/main/java/com/ktb/ktb_cj_community_spring_be/global/util/aws/config/AwsS3Config.java
@@ -1,0 +1,37 @@
+package com.ktb.ktb_cj_community_spring_be.global.util.aws.config;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Slf4j
+@Configuration
+public class AwsS3Config {
+
+
+      @Value("${cloud.aws.credentials.accessKey}")
+      private String accessKey;
+
+      @Value("${cloud.aws.credentials.secretKey}")
+      private String secretKey;
+
+      @Value("${cloud.aws.region.static}")
+      private String region;
+
+      @Bean
+      public AmazonS3 amazonS3Client() {
+            AWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
+
+            return AmazonS3ClientBuilder
+                    .standard()
+                    .withCredentials(new AWSStaticCredentialsProvider(credentials))
+                    .withRegion(region)
+                    .build();
+      }
+}

--- a/src/main/java/com/ktb/ktb_cj_community_spring_be/global/util/aws/dto/S3ImageDto.java
+++ b/src/main/java/com/ktb/ktb_cj_community_spring_be/global/util/aws/dto/S3ImageDto.java
@@ -1,0 +1,32 @@
+package com.ktb.ktb_cj_community_spring_be.global.util.aws.dto;
+
+import com.ktb.ktb_cj_community_spring_be.global.util.aws.entity.PostImage;
+import lombok.Builder;
+
+
+@Builder
+public record S3ImageDto(
+        Long id,
+        String url,
+        String fileName,
+        Long size
+) {
+
+      public static S3ImageDto fromEntity(PostImage postImage) {
+            return S3ImageDto.builder()
+                    .id(postImage.getId())
+                    .url(postImage.getUrl())
+                    .fileName(postImage.getFileName())
+                    .size(postImage.getSize())
+                    .build();
+      }
+
+      public PostImage toEntity() {
+            return PostImage.builder()
+                    .url(url)
+                    .fileName(fileName)
+                    .size(size)
+                    .build();
+      }
+
+}

--- a/src/main/java/com/ktb/ktb_cj_community_spring_be/global/util/aws/entity/PostImage.java
+++ b/src/main/java/com/ktb/ktb_cj_community_spring_be/global/util/aws/entity/PostImage.java
@@ -1,0 +1,48 @@
+package com.ktb.ktb_cj_community_spring_be.global.util.aws.entity;
+
+import com.ktb.ktb_cj_community_spring_be.global.entity.BaseEntity;
+import com.ktb.ktb_cj_community_spring_be.post.entity.Post;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+public class PostImage extends BaseEntity {
+
+      @Id
+      @GeneratedValue(strategy = GenerationType.IDENTITY)
+      private Long id;
+
+      @Column(nullable = false)
+      private String url;
+
+      @Column(nullable = false)
+      private String fileName;
+
+      @Column
+      private Long size;
+
+      @ManyToOne
+      @JoinColumn(name = "post_id")
+      private Post post;
+
+      public void mappingPost(Post post){
+            this.post = post;
+      }
+
+}

--- a/src/main/java/com/ktb/ktb_cj_community_spring_be/global/util/aws/service/AwsS3Service.java
+++ b/src/main/java/com/ktb/ktb_cj_community_spring_be/global/util/aws/service/AwsS3Service.java
@@ -1,0 +1,101 @@
+package com.ktb.ktb_cj_community_spring_be.global.util.aws.service;
+
+import static com.ktb.ktb_cj_community_spring_be.global.exception.type.ErrorCode.INTERNAL_SERVER_ERROR;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.AmazonS3Exception;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.ktb.ktb_cj_community_spring_be.global.exception.GlobalException;
+import com.ktb.ktb_cj_community_spring_be.global.exception.type.ErrorCode;
+import com.ktb.ktb_cj_community_spring_be.global.util.aws.dto.S3ImageDto;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AwsS3Service {
+
+      private final AmazonS3 amazonS3;
+
+      @Value("${cloud.aws.s3.bucket}")
+      private String bucketName;
+
+
+      public S3ImageDto uploadImage(MultipartFile multipartfile) {
+
+            String fileName = generateFileName(multipartfile);
+            uploadToS3(multipartfile, fileName);
+
+            return S3ImageDto.builder()
+                    .url(getUrl(fileName))
+                    .fileName(fileName)
+                    .size(multipartfile.getSize())
+                    .build();
+
+      }
+
+      /**
+       * AWS S3에 파일을 업로드.
+       *
+       * @param multipartFile 업로드할 파일
+       * @param fileName      파일 이름
+       */
+      public void uploadToS3(MultipartFile multipartFile, String fileName) {
+            try (InputStream inputStream = multipartFile.getInputStream()) {
+                  amazonS3.putObject(new PutObjectRequest(bucketName, fileName, inputStream,
+                          getObjectMetadata(multipartFile))
+                          .withCannedAcl(CannedAccessControlList.PublicRead));
+            } catch (IOException e) {
+                  log.error("IOException is occurred", e);
+                  throw new GlobalException(INTERNAL_SERVER_ERROR);
+            }
+      }
+
+
+      public void deleteFile(String fileName) {
+            try {
+                  amazonS3.deleteObject(bucketName, fileName);
+            } catch (AmazonS3Exception e) {
+                  log.error("AmazonS3Exception is occurred", e);
+                  throw new GlobalException(INTERNAL_SERVER_ERROR);
+            }
+      }
+
+      public String getUrl(String fileName) {
+            return amazonS3.getUrl(bucketName, fileName).toString();
+      }
+
+      public ObjectMetadata getObjectMetadata(MultipartFile multipartFile) {
+            ObjectMetadata objectMetadata = new ObjectMetadata();
+            objectMetadata.setContentType(multipartFile.getContentType());
+            objectMetadata.setContentLength(multipartFile.getSize());
+            return objectMetadata;
+      }
+
+
+      public String generateFileName(MultipartFile multipartFile) {
+            return UUID.randomUUID().toString() + "_" + multipartFile.getOriginalFilename();
+      }
+
+
+      // URL 을 사용하여 파일을 삭제하는 메서드
+      public void deleteFilesUsingUrl(String fileUrl) {
+
+            String fileName = extractFileNameFromUrl(fileUrl);
+            deleteFile(fileName); // 기존에 작성한 deleteFile 메서드를 재사용
+      }
+
+      public String extractFileNameFromUrl(String fileUrl) {
+            return fileUrl.substring(fileUrl.lastIndexOf("/") + 1);
+      }
+
+}

--- a/src/main/java/com/ktb/ktb_cj_community_spring_be/global/util/jwt/JwtAccessDeniedHandler.java
+++ b/src/main/java/com/ktb/ktb_cj_community_spring_be/global/util/jwt/JwtAccessDeniedHandler.java
@@ -1,0 +1,63 @@
+package com.ktb.ktb_cj_community_spring_be.global.util.jwt;
+
+import static com.ktb.ktb_cj_community_spring_be.global.exception.type.ErrorCode.*;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+/**
+ * JWT 인증 시, 접근 권한이 없는 사용자가 보호된 리소스에 대한 권한 없음 처리
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtAccessDeniedHandler implements AccessDeniedHandler {
+
+      //ObjectMapper 는 JSON 변환을 담당
+      private final ObjectMapper objectMapper;
+
+      /**
+       * 권한이 없는 사용자가 보호된 리소스에 접근을 시도했을 때의 처리 메소드
+       */
+      @Override
+      public void handle(HttpServletRequest request, HttpServletResponse response,
+              AccessDeniedException accessDeniedException) throws IOException, ServletException {
+
+            // 권한 없음 오류에 대한 응답을 설정
+            setResponse(response);
+
+      }
+
+      /**
+       * 권한 없음 오류에 대한 응답을 생성하고, 이를 클라이언트에 전송하는 메소드
+       * 한글 출력을 위해 getWriter() 사용
+       */
+      private void setResponse(HttpServletResponse response) throws IOException {
+
+            Map<String, Object> map = new HashMap<>();
+
+            // 오류 코드와 메시지를 응답에 포함
+            map.put("errorCode", USER_AUTHORITY_NOT_MATCH);
+            map.put("errorMessage", USER_AUTHORITY_NOT_MATCH.getDescription());
+
+            // 응답의 컨텐츠 타입과 상태 코드를 설정
+            response.setContentType("application/json;charset=UTF-8");
+            response.setStatus(USER_AUTHORITY_NOT_MATCH.getHttpStatus().value());
+
+            log.error("JWT token error -> {}", USER_AUTHORITY_NOT_MATCH);
+
+            // 응답에 JSON 형태로 변환하여 클라이언트에 전송
+            response.getWriter().println(objectMapper.writeValueAsString(map));
+
+      }
+}

--- a/src/main/java/com/ktb/ktb_cj_community_spring_be/global/util/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/ktb/ktb_cj_community_spring_be/global/util/jwt/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,69 @@
+package com.ktb.ktb_cj_community_spring_be.global.util.jwt;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ktb.ktb_cj_community_spring_be.global.exception.ErrorResponse;
+import com.ktb.ktb_cj_community_spring_be.global.exception.type.ErrorCode;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+/**
+ * 인증되지 않은 사용자가 보호된 리소스에 접근하려고 할 때 처리
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+      // ObjectMapper 는 JSON 변환을 담당
+      private final ObjectMapper objectMapper;
+
+      @Override
+      public void commence(HttpServletRequest request, HttpServletResponse response,
+              AuthenticationException authException) throws IOException, ServletException {
+
+            Object exception = request.getAttribute("exception");
+
+            // 인증 오류가 ErrorCode 형태인 경우에만 에러 응답을 생성
+            if (exception instanceof ErrorCode errorCode) {
+                  setResponse(response, errorCode);
+            }
+      }
+
+      /**
+       * 인증 오류에 대한 응답을 생성하고, 이를 클라이언트에 전송하는 메소드.
+       * 한글 출력을 위해 getWriter() 사용
+       */
+      private void setResponse(HttpServletResponse response, ErrorCode errorCode)
+              throws IOException {
+
+            Map<String, Object> map = new HashMap<>();
+
+            ErrorResponse errorResponse = new ErrorResponse(errorCode, errorCode.getHttpStatus(),
+                    errorCode.getDescription());
+
+            // 오류 코드와 메시지를 응답에 포함
+            map.put("errorCode", errorResponse.getErrorCode().name());
+            map.put("errorMessage", errorResponse.getErrorCode().getDescription());
+
+            // 응답의 컨텐츠 타입과 상태 코드를 설정
+            response.setContentType("application/json;charset=UTF-8");
+            response.setStatus(errorResponse.getHttpStatus().value());
+
+            log.error("JWT token is error -> {}", errorCode);
+
+            // 응답을 JSON 형태로 변환하여 클라이언트에 전송
+            response.getWriter().println(objectMapper.writeValueAsString(map));
+
+      }
+
+
+}

--- a/src/main/java/com/ktb/ktb_cj_community_spring_be/global/util/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/ktb/ktb_cj_community_spring_be/global/util/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,94 @@
+package com.ktb.ktb_cj_community_spring_be.global.util.jwt;
+
+import static com.ktb.ktb_cj_community_spring_be.global.exception.type.ErrorCode.UNKNOWN_ERROR;
+
+import com.ktb.ktb_cj_community_spring_be.global.exception.GlobalException;
+import com.ktb.ktb_cj_community_spring_be.global.service.RedisService;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.ObjectUtils;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+/**
+ * 요청 헤더에서 JWT 토큰을 추출하고, 토큰의 유효성 검사 토큰이 유효하면 SecurityContext 에 인증 정보를 저장
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+      private final TokenProvider tokenProvider;
+      private final RedisService redisService;
+
+      @Value("${spring.jwt.prefix}")
+      private String tokenPrefix;
+
+      @Value("${spring.jwt.header}")
+      private String tokenHeader;
+
+      /**
+       * HTTP 요청을 필터링 하여 JWT 토큰을 검증하고, 유효한 토큰일 경우 인증 정보를 SecurityContext 에 저장. 만약 토큰이 유효하지 않거나 로그아웃
+       * 된 상태라면 예외 처리
+       *
+       * @param request     HTTP 요청
+       * @param response    HTTP 응답
+       * @param filterChain 필터 체인
+       * @throws ServletException 서블릿 예외
+       * @throws IOException      입출력 예외
+       */
+
+      @Override
+      protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+              FilterChain filterChain) throws ServletException, IOException {
+
+            String token = resolveTokenFromRequest(request);
+
+            try {
+                  if (StringUtils.hasText(token) && tokenProvider.validateToken(token)) {
+                        // Redis 에서 토큰에 대한 데이터가 없는 경우 (로그아웃 상태 아님)
+                        if (Objects.isNull(redisService.getData(token))) {
+                              // 토큰으로부터 인증 정보를 받아옴
+                              Authentication authentication = tokenProvider.getAuthentication(
+                                      token);
+                              log.info("getAuthentication method called with token: {}", token);
+
+                              //SecurityContext 에 인증 정보를 저장
+                              SecurityContextHolder.getContext().setAuthentication(authentication);
+                              log.info("Authentication object stored in SecurityContext: {}",
+                                      authentication);
+                        } else {
+                              // redis 에서 토큰에 대한 데이터가 있는 경우 (로그아웃 상태)
+                              request.setAttribute("exception", UNKNOWN_ERROR);
+                        }
+                  }
+            } catch (GlobalException e) {
+                  request.setAttribute("exception", UNKNOWN_ERROR);
+
+            }
+      }
+
+      /**
+       * HTTP 요청 헤더에서 JWT 토큰 추출하여 반납.
+       *
+       * @param request HTTP 요청
+       * @return 추출한 JWT 토큰 or null
+       */
+      private String resolveTokenFromRequest(HttpServletRequest request) {
+            String token = request.getHeader(this.tokenHeader);
+            if (!ObjectUtils.isEmpty(token) && token.startsWith(this.tokenPrefix)) {
+                  return token.substring(this.tokenPrefix.length());
+            }
+            return null;
+      }
+}

--- a/src/main/java/com/ktb/ktb_cj_community_spring_be/global/util/jwt/JwtUserDetailService.java
+++ b/src/main/java/com/ktb/ktb_cj_community_spring_be/global/util/jwt/JwtUserDetailService.java
@@ -1,0 +1,37 @@
+package com.ktb.ktb_cj_community_spring_be.global.util.jwt;
+
+import static com.ktb.ktb_cj_community_spring_be.global.exception.type.ErrorCode.USER_NOT_FOUND;
+
+import com.ktb.ktb_cj_community_spring_be.global.exception.GlobalException;
+import com.ktb.ktb_cj_community_spring_be.global.util.jwt.dto.CustomUserDto;
+import com.ktb.ktb_cj_community_spring_be.member.entity.Member;
+import com.ktb.ktb_cj_community_spring_be.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+/**
+ * 사용자를 인증하기 위해 UserDetailsService 인터페이스를 구현한 클래스
+ *
+ * 주어진 이메일 기반으로 사용자 정보를 로드
+ * JWT 기반 인증을 위해 필요한 UserDetails 객체를 반환
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class JwtUserDetailService implements UserDetailsService {
+
+      private final MemberRepository memberRepository;
+
+      @Override
+      public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+
+            Member member = memberRepository.findByEmail(email)
+                    .orElseThrow(() -> new GlobalException(USER_NOT_FOUND));
+
+            return new JwtUserDetails(CustomUserDto.fromEntity(member));
+      }
+}

--- a/src/main/java/com/ktb/ktb_cj_community_spring_be/global/util/jwt/JwtUserDetails.java
+++ b/src/main/java/com/ktb/ktb_cj_community_spring_be/global/util/jwt/JwtUserDetails.java
@@ -1,0 +1,46 @@
+package com.ktb.ktb_cj_community_spring_be.global.util.jwt;
+
+import com.ktb.ktb_cj_community_spring_be.global.util.jwt.dto.CustomUserDto;
+import java.util.Collection;
+import java.util.List;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+public record JwtUserDetails(CustomUserDto customUserDto) implements UserDetails {
+
+      @Override
+      public Collection<? extends GrantedAuthority> getAuthorities() {
+            return List.of(new SimpleGrantedAuthority(customUserDto.getRoleType()));
+      }
+
+      @Override
+      public String getPassword() {
+            return customUserDto.getPassword();
+      }
+
+      @Override
+      public String getUsername() {
+            return customUserDto.getEmail();
+      }
+
+      @Override
+      public boolean isAccountNonExpired() {
+            return true;
+      }
+
+      @Override
+      public boolean isAccountNonLocked() {
+            return true;
+      }
+
+      @Override
+      public boolean isCredentialsNonExpired() {
+            return true;
+      }
+
+      @Override
+      public boolean isEnabled() {
+            return true;
+      }
+}

--- a/src/main/java/com/ktb/ktb_cj_community_spring_be/global/util/jwt/TokenProvider.java
+++ b/src/main/java/com/ktb/ktb_cj_community_spring_be/global/util/jwt/TokenProvider.java
@@ -1,0 +1,170 @@
+package com.ktb.ktb_cj_community_spring_be.global.util.jwt;
+
+import static com.ktb.ktb_cj_community_spring_be.global.exception.type.ErrorCode.*;
+
+import com.ktb.ktb_cj_community_spring_be.global.exception.GlobalException;
+
+import com.ktb.ktb_cj_community_spring_be.global.util.jwt.dto.TokenDto;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.security.Keys;
+
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
+import java.util.Base64;
+import java.util.Date;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.stereotype.Component;
+
+/**
+ * JWT 토큰을 생성하고 검증
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class TokenProvider {
+
+      @Value("${spring.jwt.secret}")
+      private String secretKey;
+
+      @Value("${spring.jwt.access-token-expire-time}")
+      private Long accessTokenExpiration;
+
+      @Value("${spring.jwt.refresh-token-expire-time}")
+      private Long refreshTokenExpiration;
+
+      private static final String KEY_ROLES = "roles";
+      private static final String USER_ID = "userId";
+
+      private final JwtUserDetailService userDetailService;
+
+
+      /**
+       * 주어진 이메일과 roleType(권한)에 대해 엑세스 토큰과 리프레시 토큰 생성
+       *
+       * @param email    사요자 이메일 주소
+       * @param roleType 사용자 유형
+       * @return 생성된 엑세스 토큰과 리프레시 토큰 정보가 담긴 TokenDto 객체
+       */
+      public TokenDto generateToken(String email, String roleType) {
+            Date now = new Date();
+
+            Date accessTokenExpireTime = new Date(now.getTime() + accessTokenExpiration);
+            Date refreshTokenExpireTime = new Date(now.getTime() + refreshTokenExpiration);
+
+            String accessToken = Jwts.builder()
+                    .setSubject("access-token")
+                    .claim(KEY_ROLES, roleType)
+                    .claim(USER_ID, email)
+                    .setIssuedAt(now) // 토큰 생성 시간
+                    .setExpiration(accessTokenExpireTime) // 토큰 만료 시간
+                    .signWith(getSigningKey(), SignatureAlgorithm.HS256) // 사용할 암호화 알고리즘 비밀키
+                    .compact();
+            log.info("Email stored in accessToken: {}", email);
+
+            String refreshToken = Jwts.builder()
+                    .setSubject("refresh-token")
+                    .claim(KEY_ROLES, roleType)
+                    .claim(USER_ID, email)
+                    .setIssuedAt(now) // 토큰 생성 시간
+                    .setExpiration(refreshTokenExpireTime) // 토큰 만료 시간
+                    .signWith(getSigningKey(), SignatureAlgorithm.HS256) // 사용할 암호화 알고리즘 비밀키
+                    .compact();
+
+            return TokenDto.builder()
+                    .accessToken(accessToken)
+                    .refreshToken(refreshToken)
+                    .accessTokenExpireTime(accessTokenExpireTime.getTime())
+                    .refreshTokenExpireTime(refreshTokenExpireTime.getTime())
+                    .build();
+      }
+
+      /**
+       * 주어진 토큰이 유효한지 검증. 토큰이 유효하지 않은 경우, 예외 발생
+       *
+       * @param token 검증할 JWT 토큰
+       * @return 토큰의 유효성 검증 결과(유효할 경우 true, 그렇지 않을 경우 false)
+       */
+      public boolean validateToken(String token) {
+            try {
+                  Claims claims = this.parseClaims(token);
+                  return !claims.getExpiration()
+                          .before(new Date()); // 토큰의 만료시간이 현재의 시간보다 이전인지 아닌지 확인
+            } catch (SecurityException | MalformedJwtException e) {
+                  log.error("Invalid JWT token: {}", e.getMessage());
+                  throw new GlobalException(INVALID_TOKEN);
+            } catch (ExpiredJwtException e) {
+                  log.error("JWT token is expired: {}", e.getMessage());
+                  throw new GlobalException(EXPIRED_TOKEN);
+            } catch (UnsupportedJwtException e) {
+                  log.error("JWT token is unsupported: {}", e.getMessage());
+                  throw new GlobalException(UNSUPPORTED_TOKEN);
+            } catch (IllegalArgumentException e) {
+                  log.error("JWT token is wrong type: {}", e.getMessage());
+                  throw new GlobalException(WRONG_TYPE_TOKEN);
+            }
+      }
+
+      /**
+       * 주어진 토큰에 대한 인증 정보를 반환
+       *
+       * @param token 인증 정보를 추출할 JWT 토큰
+       * @return 토큰에 담긴 인증 정보 (Authentication 객체)
+       */
+      public Authentication getAuthentication(String token) {
+            Claims claims = this.parseClaims(token);
+            log.info("Claims object: {}", claims);
+
+            String userId = claims.get(USER_ID).toString();
+            log.info("Extracted userId from token: {}", userId);
+
+            JwtUserDetails userDetails = (JwtUserDetails) userDetailService
+                    .loadUserByUsername(userId);
+            log.info("UserDetails object: {}", userDetails);
+
+            return new UsernamePasswordAuthenticationToken(userDetails, "",
+                    userDetails.getAuthorities());
+      }
+
+
+
+      /**
+       * 주어진 토큰을 파싱하여 Claims 객체로 반환
+       *
+       * @return 토큰의 Claims 객체
+       */
+      private Claims parseClaims(String token) {
+            return Jwts.parserBuilder()
+                    .setSigningKey(getSigningKey())
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody();
+      }
+
+
+      /**
+       * Base64 인코딩된 secretKey 를 반환
+       */
+      private Key getSigningKey() {
+            String encoded = Base64.getEncoder().encodeToString(
+                    secretKey.getBytes(StandardCharsets.UTF_8));
+
+            return Keys.hmacShaKeyFor(encoded.getBytes());
+      }
+
+      /**
+       *  주어진 토큰 만료 시간을 반환
+       */
+
+      public Long getExpireTime(String token){
+            return this.parseClaims(token).getExpiration().getTime();
+      }
+}

--- a/src/main/java/com/ktb/ktb_cj_community_spring_be/global/util/jwt/dto/CustomUserDto.java
+++ b/src/main/java/com/ktb/ktb_cj_community_spring_be/global/util/jwt/dto/CustomUserDto.java
@@ -24,7 +24,7 @@ public class CustomUserDto {
                     .id(member.getId())
                     .email(member.getEmail())
                     .password(member.getPassword())
-                    .roleType(member.getRoleType())
+                    .roleType(member.getRoleType().getCode())
                     .build();
       }
 

--- a/src/main/java/com/ktb/ktb_cj_community_spring_be/global/util/jwt/dto/CustomUserDto.java
+++ b/src/main/java/com/ktb/ktb_cj_community_spring_be/global/util/jwt/dto/CustomUserDto.java
@@ -1,0 +1,31 @@
+package com.ktb.ktb_cj_community_spring_be.global.util.jwt.dto;
+
+import com.ktb.ktb_cj_community_spring_be.member.entity.Member;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CustomUserDto {
+
+      private Long id;
+      private String email;
+      private String password;
+      private String roleType;
+
+      public static CustomUserDto fromEntity(Member member) {
+            return CustomUserDto.builder()
+                    .id(member.getId())
+                    .email(member.getEmail())
+                    .password(member.getPassword())
+                    .roleType(member.getRoleType())
+                    .build();
+      }
+
+}

--- a/src/main/java/com/ktb/ktb_cj_community_spring_be/global/util/jwt/dto/TokenDto.java
+++ b/src/main/java/com/ktb/ktb_cj_community_spring_be/global/util/jwt/dto/TokenDto.java
@@ -1,0 +1,20 @@
+package com.ktb.ktb_cj_community_spring_be.global.util.jwt.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class TokenDto {
+
+      private String accessToken;
+      private String refreshToken;
+      private Long accessTokenExpireTime;
+      private Long refreshTokenExpireTime;
+}

--- a/src/main/java/com/ktb/ktb_cj_community_spring_be/member/entity/Member.java
+++ b/src/main/java/com/ktb/ktb_cj_community_spring_be/member/entity/Member.java
@@ -3,6 +3,7 @@ package com.ktb.ktb_cj_community_spring_be.member.entity;
 import com.ktb.ktb_cj_community_spring_be.comment.entity.Comment;
 import com.ktb.ktb_cj_community_spring_be.comment.entity.CommentLike;
 import com.ktb.ktb_cj_community_spring_be.global.entity.BaseEntity;
+import com.ktb.ktb_cj_community_spring_be.member.entity.type.MemberRoleType;
 import com.ktb.ktb_cj_community_spring_be.post.entity.Post;
 import com.ktb.ktb_cj_community_spring_be.post.entity.PostLike;
 import jakarta.persistence.*;
@@ -24,39 +25,42 @@ import lombok.Setter;
 @Builder
 public class Member extends BaseEntity {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+      @Id
+      @GeneratedValue(strategy = GenerationType.IDENTITY)
+      private Long id;
 
-    @Column(nullable = false, unique = true)
-    private String email;
+      @Column(nullable = false, unique = true)
+      private String email;
 
-    @Column(nullable = false)
-    private String password;
+      @Column(nullable = false)
+      private String password;
 
-    @Column(nullable = false, unique = true, length = 50)
-    private String nickname;
+      @Column(nullable = false, unique = true, length = 50)
+      private String nickname;
 
-    @Column(nullable = false, length = 50)
-    private String role;
+      @Column(nullable = false, length = 50)
+      private MemberRoleType roleType;
 
-    @Builder.Default
-    private boolean emailAuth = false;
+      @Column(nullable = false)
+      private String profileImageUrl;
 
-    @Builder.Default
-    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<Post> posts = new ArrayList<>();
+//    @Builder.Default
+//    private boolean emailAuth = false;
 
-    @Builder.Default
-    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<Comment> comments = new ArrayList<>();
+      @Builder.Default
+      @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+      private List<Post> posts = new ArrayList<>();
 
-    @Builder.Default
-    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<PostLike> postLikes = new ArrayList<>();
+      @Builder.Default
+      @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+      private List<Comment> comments = new ArrayList<>();
 
-    @Builder.Default
-    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<CommentLike> commentLikes = new ArrayList<>();
+      @Builder.Default
+      @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+      private List<PostLike> postLikes = new ArrayList<>();
+
+      @Builder.Default
+      @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+      private List<CommentLike> commentLikes = new ArrayList<>();
 
 }

--- a/src/main/java/com/ktb/ktb_cj_community_spring_be/member/entity/type/MemberRoleType.java
+++ b/src/main/java/com/ktb/ktb_cj_community_spring_be/member/entity/type/MemberRoleType.java
@@ -1,0 +1,14 @@
+package com.ktb.ktb_cj_community_spring_be.member.entity.type;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum MemberRoleType {
+
+      USER("ROLE_USER"),
+      ADMIN("ROLE_ADMIN");
+
+      private final String code;
+}

--- a/src/main/java/com/ktb/ktb_cj_community_spring_be/member/repository/MemberRepository.java
+++ b/src/main/java/com/ktb/ktb_cj_community_spring_be/member/repository/MemberRepository.java
@@ -1,0 +1,15 @@
+package com.ktb.ktb_cj_community_spring_be.member.repository;
+
+import com.ktb.ktb_cj_community_spring_be.member.entity.Member;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+      Optional<Member> findByEmail(String email);
+
+      boolean existsByEmail(String email);
+
+}

--- a/src/test/java/com/ktb/ktb_cj_community_spring_be/global/service/RedisServiceTest.java
+++ b/src/test/java/com/ktb/ktb_cj_community_spring_be/global/service/RedisServiceTest.java
@@ -1,0 +1,23 @@
+package com.ktb.ktb_cj_community_spring_be.global.service;
+
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+
+@SpringBootTest
+class RedisServiceTest {
+
+      @Autowired
+      private RedisService redisService;
+
+
+
+      @Test
+      void testSaveRedisData() {
+            //given
+            //then
+      }
+}


### PR DESCRIPTION
Based on the content of `AuthServiceImpl.java` and `AuthController.java`, here is a detailed PR template including the implementation of the Auth API:

---

# Pull Request Template

## 변경사항
<!-- 이 PR에서 어떤 점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->

**AS-IS**
- 사용자 권한 및 인증 정보 관리 기능이 없음
- Redis DB 연결 기능이 없음
- 회원 권한 필드 변수명이 role
- JWT 인증 및 접근 제어 관련 클래스가 없음
- 인증 API가 구현되어 있지 않음

**TO-BE**
- JwtUserDetails 및 JwtUserDetailService 구현으로 사용자 권한 및 인증 정보 관리
- RedisConfig 및 RedisService 구현으로 Redis DB 연결 설정
- 회원 권한 필드 변수명을 role에서 roleType으로 변경
- JWT 관련 핸들러 및 DTO 클래스 추가로 JWT 인증 및 접근 제어 기능 구현
- Auth API 구현 (`AuthServiceImpl.java` 및 `AuthController.java`)


## Auth API 구현 내용
- `AuthServiceImpl.java`
  - `signUp(SignUpDto request, MultipartFile profileImage)`: 회원 가입 로직 구현
  - `signIn(SignInDto request)`: 로그인 로직 구현
  - `logout(LogoutDto request)`: 로그아웃 로직 구현
  - `reissue(ReissueDto request)`: 토큰 재발급 로직 구현


## 테스트
<!-- 본 변경사항이 테스트되었는지 기술해주세요 -->
- [ ] 테스트 코드 작성
- [ ] API 테스트 완료

