### PR TITLE
feat: 로그인 사용자 정보 처리 및 게시물 요청/응답 기능 추가

### DIFF
--- a/src/main/java/com/ktb/ktb_cj_community_spring_be/auth/config/LoginUser.java
+++ b/src/main/java/com/ktb/ktb_cj_community_spring_be/auth/config/LoginUser.java
@@ -1,0 +1,16 @@
+package com.ktb.ktb_cj_community_spring_be.auth.config;
+
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * 현재 로그인한 사용자의 정보를 가져오는데
+ */
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface LoginUser {
+
+}

--- a/src/main/java/com/ktb/ktb_cj_community_spring_be/auth/config/LoginUserArgumentResolver.java
+++ b/src/main/java/com/ktb/ktb_cj_community_spring_be/auth/config/LoginUserArgumentResolver.java
@@ -1,0 +1,44 @@
+package com.ktb.ktb_cj_community_spring_be.auth.config;
+
+import com.ktb.ktb_cj_community_spring_be.global.exception.GlobalException;
+import com.ktb.ktb_cj_community_spring_be.global.exception.type.ErrorCode;
+import java.util.Objects;
+import org.springframework.core.MethodParameter;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+/**
+ * 컨트롤러 메소드에서 로그인 사용자 정보를 파라미터로 받을 수 있도록 지원
+ */
+@Component
+public class LoginUserArgumentResolver implements HandlerMethodArgumentResolver {
+
+      /**
+       * 파라미터가 @LoginUSer 어노테이션을 가지고 있고, String 타입인 경우에만 true 반환
+       */
+      @Override
+      public boolean supportsParameter(MethodParameter parameter) {
+            boolean isLoginUserAnnotation = parameter.hasMethodAnnotation(LoginUser.class);
+            boolean isUserClass = String.class.equals(parameter.getParameterType());
+
+            return isLoginUserAnnotation && isUserClass;
+      }
+
+      @Override
+      public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+              NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+
+            Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+            if (Objects.isNull(authentication)) {
+                  throw new GlobalException(ErrorCode.UNKNOWN_ERROR);
+
+            }
+            return authentication.getName();
+      }
+}

--- a/src/main/java/com/ktb/ktb_cj_community_spring_be/global/util/aws/entity/PostImage.java
+++ b/src/main/java/com/ktb/ktb_cj_community_spring_be/global/util/aws/entity/PostImage.java
@@ -41,8 +41,9 @@ public class PostImage extends BaseEntity {
       @JoinColumn(name = "post_id")
       private Post post;
 
-      public void mappingPost(Post post){
+      public void mappingPost(Post post) {
             this.post = post;
+
       }
 
 }

--- a/src/main/java/com/ktb/ktb_cj_community_spring_be/post/dto/PostRequest.java
+++ b/src/main/java/com/ktb/ktb_cj_community_spring_be/post/dto/PostRequest.java
@@ -1,0 +1,40 @@
+package com.ktb.ktb_cj_community_spring_be.post.dto;
+
+
+import com.ktb.ktb_cj_community_spring_be.global.util.aws.entity.PostImage;
+import com.ktb.ktb_cj_community_spring_be.post.entity.Post;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class PostRequest {
+
+
+      @NotNull(message = "제목을 입력해주세요.")
+      private String title;
+      @NotNull(message = "내용을 입력해주세요.")
+      private String content;
+
+      private List<PostImage> images;
+
+
+      public Post toEntity() {
+            return Post.builder()
+                    .title(title)
+                    .content(content)
+                    .build();
+      }
+
+      public void updatePostEntity(Post post) {
+            post.setTitle(title);
+            post.setContent(content);
+      }
+
+
+}

--- a/src/main/java/com/ktb/ktb_cj_community_spring_be/post/dto/PostResponse.java
+++ b/src/main/java/com/ktb/ktb_cj_community_spring_be/post/dto/PostResponse.java
@@ -1,0 +1,49 @@
+package com.ktb.ktb_cj_community_spring_be.post.dto;
+
+
+import com.ktb.ktb_cj_community_spring_be.global.util.aws.dto.S3ImageDto;
+import com.ktb.ktb_cj_community_spring_be.post.entity.Post;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PostResponse {
+
+      private Long id;
+      private Long memberId;
+      private String memberEmail;
+
+      private String title;
+      private String content;
+      private List<S3ImageDto> images;
+
+      private LocalDateTime createdAt;
+      private LocalDateTime updatedAt;
+
+
+      public static PostResponse fromEntity(Post post) {
+            List<S3ImageDto> imageList = post.getImages().stream()
+                    .map(S3ImageDto::fromEntity).toList();
+
+            return PostResponse.builder()
+                    .id(post.getId())
+                    .memberId(post.getMember().getId())
+                    .memberEmail(post.getMember().getEmail())
+                    .title(post.getTitle())
+                    .content(post.getContent())
+                    .images(imageList)
+                    .createdAt(post.getCreatedAt())
+                    .updatedAt(post.getUpdatedAt())
+                    .build();
+      }
+
+}

--- a/src/main/java/com/ktb/ktb_cj_community_spring_be/post/entity/Post.java
+++ b/src/main/java/com/ktb/ktb_cj_community_spring_be/post/entity/Post.java
@@ -2,6 +2,7 @@ package com.ktb.ktb_cj_community_spring_be.post.entity;
 
 import com.ktb.ktb_cj_community_spring_be.comment.entity.Comment;
 import com.ktb.ktb_cj_community_spring_be.global.entity.BaseEntity;
+import com.ktb.ktb_cj_community_spring_be.global.util.aws.entity.PostImage;
 import com.ktb.ktb_cj_community_spring_be.member.entity.Member;
 import jakarta.persistence.*;
 import java.util.ArrayList;
@@ -46,4 +47,18 @@ public class Post extends BaseEntity {
 
       @OneToMany(mappedBy = "post", cascade = CascadeType.ALL)
       private List<PostLike> postLikes = new ArrayList<>();
+
+      @Builder.Default
+      @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
+      private List<PostImage> images = new ArrayList<>();
+
+      public void addImage(PostImage image) {
+            this.images.add(image);
+            image.mappingPost(this);
+      }
+
+      public void removeImage(PostImage image) {
+            this.images.remove(image);
+      }
+
 }

--- a/src/main/java/com/ktb/ktb_cj_community_spring_be/post/service/PostService.java
+++ b/src/main/java/com/ktb/ktb_cj_community_spring_be/post/service/PostService.java
@@ -1,0 +1,23 @@
+package com.ktb.ktb_cj_community_spring_be.post.service;
+
+import com.ktb.ktb_cj_community_spring_be.post.dto.PostRequest;
+import com.ktb.ktb_cj_community_spring_be.post.dto.PostResponse;
+import com.ktb.ktb_cj_community_spring_be.post.entity.Post;
+import java.util.List;
+import org.springframework.web.multipart.MultipartFile;
+
+public interface PostService {
+
+
+      PostResponse createPost(PostRequest request, List<MultipartFile> images, String email);
+
+      PostResponse readPost(Long postId);
+
+      PostResponse updatePost(Long id, PostRequest request, List<MultipartFile> newImages,
+              List<Long> imageIdsToDelete, String email);
+
+      PostResponse deletePost(Long id, String email);
+
+      Post uploadS3Image(PostRequest request, List<MultipartFile> multipartFiles);
+
+}

--- a/src/main/java/com/ktb/ktb_cj_community_spring_be/post/web/PostController.java
+++ b/src/main/java/com/ktb/ktb_cj_community_spring_be/post/web/PostController.java
@@ -1,0 +1,9 @@
+package com.ktb.ktb_cj_community_spring_be.post.web;
+
+
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class PostController {
+
+}


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤 점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
- 로그인 사용자 정보를 가져오는 기능이 없었음
- 게시물 요청 및 응답 처리가 불가능했음
- Post API 관련 기본 작업 미비

**TO-BE**
- `@LoginUser` 어노테이션을 통해 현재 로그인한 사용자 정보를 파라미터로 받을 수 있는 기능 추가
- `LoginUserArgumentResolver` 클래스 구현으로 `@LoginUser` 어노테이션이 적용된 파라미터를 처리
- `PostRequest` 클래스 추가로 게시물 생성 시 요청 데이터 처리
- `PostResponse` 클래스 추가로 게시물 응답 데이터 처리
- `PostImage` 클래스에 게시물 이미지 매핑 메서드 추가
- `Post` 엔티티 클래스에 이미지 리스트 필드 및 관련 메서드 추가
- `PostService` 인터페이스에 게시물 CRUD 메서드 정의
- `PostController` 클래스 추가로 기본 컨트롤러 설정

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드 작성
- [ ] API 테스트 완료

