### PR TITLE
feat: 게시물 좋아요 기능 및 페이징 기능 추가

### DIFF
--- a/src/main/java/com/ktb/ktb_cj_community_spring_be/global/exception/type/ErrorCode.java
+++ b/src/main/java/com/ktb/ktb_cj_community_spring_be/global/exception/type/ErrorCode.java
@@ -22,7 +22,8 @@ public enum ErrorCode {
       COMMENT_NOT_FOUND(HttpStatus.BAD_REQUEST, "해당 댓글을 찾을 수 없습니다."),
       PROFILE_IMAGE_UPLOAD_ERROR(HttpStatus.BAD_REQUEST, "프로필 이미지 업로드 중 오류가 발생했습니다."),
       POST_IMAGE_UPLOAD_ERROR(HttpStatus.BAD_REQUEST, "게시물 이미지 업로드 중 오류가 발생했습니다."),
-
+      ALREADY_LIKED(HttpStatus.BAD_REQUEST, "이미 좋아요를 누른 게시물입니다."),
+      ALREADY_UNLIKED(HttpStatus.BAD_REQUEST, "이미 좋아요를 취소한 게시물입니다."),
 
       /**
        * 401 Unauthorized

--- a/src/main/java/com/ktb/ktb_cj_community_spring_be/member/entity/Member.java
+++ b/src/main/java/com/ktb/ktb_cj_community_spring_be/member/entity/Member.java
@@ -6,7 +6,13 @@ import com.ktb.ktb_cj_community_spring_be.global.entity.BaseEntity;
 import com.ktb.ktb_cj_community_spring_be.member.entity.type.MemberRoleType;
 import com.ktb.ktb_cj_community_spring_be.post.entity.Post;
 import com.ktb.ktb_cj_community_spring_be.post.entity.PostLike;
-import jakarta.persistence.*;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
@@ -71,5 +77,10 @@ public class Member extends BaseEntity {
       public void removePost(Post post) {
             this.posts.remove(post);
             post.setMember(null);
+
+      }
+
+      public void addPostLike(PostLike postLike) {
+            this.postLikes.add(postLike);
       }
 }

--- a/src/main/java/com/ktb/ktb_cj_community_spring_be/member/service/MemberService.java
+++ b/src/main/java/com/ktb/ktb_cj_community_spring_be/member/service/MemberService.java
@@ -1,0 +1,5 @@
+package com.ktb.ktb_cj_community_spring_be.member.service;
+
+public class MemberService {
+
+}

--- a/src/main/java/com/ktb/ktb_cj_community_spring_be/post/dto/PostLikeResponse.java
+++ b/src/main/java/com/ktb/ktb_cj_community_spring_be/post/dto/PostLikeResponse.java
@@ -1,0 +1,13 @@
+package com.ktb.ktb_cj_community_spring_be.post.dto;
+
+import lombok.Builder;
+
+@Builder
+public record PostLikeResponse(
+        Long memberId,
+        String memberEmail,
+        Long postId,
+        boolean isLike
+) {
+
+}

--- a/src/main/java/com/ktb/ktb_cj_community_spring_be/post/entity/Post.java
+++ b/src/main/java/com/ktb/ktb_cj_community_spring_be/post/entity/Post.java
@@ -4,7 +4,16 @@ import com.ktb.ktb_cj_community_spring_be.comment.entity.Comment;
 import com.ktb.ktb_cj_community_spring_be.global.entity.BaseEntity;
 import com.ktb.ktb_cj_community_spring_be.global.util.aws.entity.PostImage;
 import com.ktb.ktb_cj_community_spring_be.member.entity.Member;
-import jakarta.persistence.*;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
@@ -61,4 +70,15 @@ public class Post extends BaseEntity {
             this.images.remove(image);
       }
 
+      public void addPostLike(PostLike postLike) {
+            this.postLikes.add(postLike);
+      }
+
+      public void removePostLike(PostLike postLike) {
+            this.postLikes.remove(postLike);
+      }
+
+      public void updateLikeCount() {
+            this.likeCount = this.postLikes.size();
+      }
 }

--- a/src/main/java/com/ktb/ktb_cj_community_spring_be/post/entity/PostLike.java
+++ b/src/main/java/com/ktb/ktb_cj_community_spring_be/post/entity/PostLike.java
@@ -2,7 +2,13 @@ package com.ktb.ktb_cj_community_spring_be.post.entity;
 
 import com.ktb.ktb_cj_community_spring_be.global.entity.BaseEntity;
 import com.ktb.ktb_cj_community_spring_be.member.entity.Member;
-import jakarta.persistence.*;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -29,5 +35,15 @@ public class PostLike extends BaseEntity {
       @ManyToOne(fetch = FetchType.LAZY)
       @JoinColumn(name = "memebr_id")
       private Member member;
+
+      public void addMember(Member member) {
+            this.member = member;
+            member.addPostLike(this);
+      }
+
+      public void addPost(Post post) {
+            this.post = post;
+            post.addPostLike(this);
+      }
 
 }

--- a/src/main/java/com/ktb/ktb_cj_community_spring_be/post/repository/PostLikeRepository.java
+++ b/src/main/java/com/ktb/ktb_cj_community_spring_be/post/repository/PostLikeRepository.java
@@ -1,0 +1,15 @@
+package com.ktb.ktb_cj_community_spring_be.post.repository;
+
+import com.ktb.ktb_cj_community_spring_be.post.entity.PostLike;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
+
+      boolean existsPostLikeByPostIdAndMember_Email(Long postId, String email);
+
+      Optional<PostLike> findByPostIdAndMember_Email(Long postId, String email);
+
+}

--- a/src/main/java/com/ktb/ktb_cj_community_spring_be/post/repository/impl/CustomPostRepositoryImpl.java
+++ b/src/main/java/com/ktb/ktb_cj_community_spring_be/post/repository/impl/CustomPostRepositoryImpl.java
@@ -1,10 +1,9 @@
 package com.ktb.ktb_cj_community_spring_be.post.repository.impl;
 
-import com.ktb.ktb_cj_community_spring_be.post.entity.Post;
-import com.ktb.ktb_cj_community_spring_be.post.repository.CustomPostRepository;
-
 import static com.ktb.ktb_cj_community_spring_be.post.entity.QPost.post;
 
+import com.ktb.ktb_cj_community_spring_be.post.entity.Post;
+import com.ktb.ktb_cj_community_spring_be.post.repository.CustomPostRepository;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
@@ -55,6 +54,21 @@ public class CustomPostRepositoryImpl implements CustomPostRepository {
                   return null;
             }
             return post.id.lt(postId);
+      }
+
+      public Slice<Post> findAllPosts(Long postId, Pageable pageable) {
+            List<Post> postList = jpa
+                    .selectFrom(post)
+                    .where(ltPostId(postId))
+                    .orderBy(
+                            post.id.desc()
+                            , post.hits.desc()
+                            , post.likeCount.desc()
+                    )
+                    .limit(pageable.getPageSize() + 1)
+                    .fetch();
+
+            return checkLastPage(pageable, postList);
       }
 
       private Slice<Post> checkLastPage(Pageable pageable, List<Post> results) {

--- a/src/main/java/com/ktb/ktb_cj_community_spring_be/post/service/PostLikeService.java
+++ b/src/main/java/com/ktb/ktb_cj_community_spring_be/post/service/PostLikeService.java
@@ -1,0 +1,11 @@
+package com.ktb.ktb_cj_community_spring_be.post.service;
+
+import com.ktb.ktb_cj_community_spring_be.post.dto.PostLikeResponse;
+
+public interface PostLikeService {
+
+      PostLikeResponse likePost(Long postId, String email);
+
+      PostLikeResponse unlikePost(Long postId, String email);
+
+}

--- a/src/main/java/com/ktb/ktb_cj_community_spring_be/post/service/PostService.java
+++ b/src/main/java/com/ktb/ktb_cj_community_spring_be/post/service/PostService.java
@@ -4,6 +4,9 @@ import com.ktb.ktb_cj_community_spring_be.post.dto.PostRequest;
 import com.ktb.ktb_cj_community_spring_be.post.dto.PostResponse;
 import com.ktb.ktb_cj_community_spring_be.post.entity.Post;
 import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.web.multipart.MultipartFile;
 
 public interface PostService {
@@ -20,4 +23,9 @@ public interface PostService {
 
       Post uploadS3Image(PostRequest request, List<MultipartFile> multipartFiles);
 
+      // 게시물 전체 리스트 - 페이징 처리
+      Page<PostResponse> postList(Pageable pageable);
+
+      // 게시물 전체 리스트 - 무한 스크롤
+      Slice<PostResponse> postListScroll(Pageable pageable);
 }

--- a/src/main/java/com/ktb/ktb_cj_community_spring_be/post/service/impl/PostLikeServiceImpl.java
+++ b/src/main/java/com/ktb/ktb_cj_community_spring_be/post/service/impl/PostLikeServiceImpl.java
@@ -1,0 +1,75 @@
+package com.ktb.ktb_cj_community_spring_be.post.service.impl;
+
+import static com.ktb.ktb_cj_community_spring_be.global.exception.type.ErrorCode.ALREADY_LIKED;
+import static com.ktb.ktb_cj_community_spring_be.global.exception.type.ErrorCode.POST_NOT_FOUND;
+import static com.ktb.ktb_cj_community_spring_be.global.exception.type.ErrorCode.USER_NOT_FOUND;
+
+import com.ktb.ktb_cj_community_spring_be.global.exception.GlobalException;
+import com.ktb.ktb_cj_community_spring_be.member.entity.Member;
+import com.ktb.ktb_cj_community_spring_be.member.repository.MemberRepository;
+import com.ktb.ktb_cj_community_spring_be.post.dto.PostLikeResponse;
+import com.ktb.ktb_cj_community_spring_be.post.entity.Post;
+import com.ktb.ktb_cj_community_spring_be.post.entity.PostLike;
+import com.ktb.ktb_cj_community_spring_be.post.repository.PostLikeRepository;
+import com.ktb.ktb_cj_community_spring_be.post.repository.PostRepository;
+import com.ktb.ktb_cj_community_spring_be.post.service.PostLikeService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PostLikeServiceImpl implements PostLikeService {
+
+      private final PostRepository postRepository;
+      private final PostLikeRepository postLikeRepository;
+      private final MemberRepository memberRepository;
+
+      @Override
+      public PostLikeResponse likePost(Long postId, String email) {
+            if (postLikeRepository.existsPostLikeByPostIdAndMember_Email(postId, email)) {
+                  throw new GlobalException(ALREADY_LIKED);
+            }
+
+            Post post = postRepository.findById(postId)
+                    .orElseThrow(() -> new GlobalException(POST_NOT_FOUND));
+
+            Member member = memberRepository.findByEmail(email)
+                    .orElseThrow(() -> new GlobalException(USER_NOT_FOUND));
+
+            PostLike postLike = PostLike.builder().build();
+
+            postLike.addMember(member);
+            postLike.addPost(post);
+            post.updateLikeCount();
+
+            postLikeRepository.save(postLike);
+            return PostLikeResponse.builder()
+                    .postId(postId)
+                    .memberId(member.getId())
+                    .memberEmail(member.getEmail())
+                    .isLike(true)
+                    .build();
+      }
+
+      @Override
+      public PostLikeResponse unlikePost(Long postId, String email) {
+
+            return postLikeRepository.findByPostIdAndMember_Email(postId, email)
+                    .map(postLike -> {
+                          postLikeRepository.delete(postLike);
+                          postRepository.findById(postId).ifPresent(e -> {
+                                e.removePostLike(postLike);
+                                e.updateLikeCount();
+                          });
+
+                          return PostLikeResponse.builder()
+                                  .postId(postId)
+                                  .memberId(postLike.getMember().getId())
+                                  .memberEmail(postLike.getMember().getEmail())
+                                  .isLike(false)
+                                  .build();
+                    }).orElseThrow(() -> new GlobalException(POST_NOT_FOUND));
+      }
+}

--- a/src/main/java/com/ktb/ktb_cj_community_spring_be/post/service/impl/PostServiceImpl.java
+++ b/src/main/java/com/ktb/ktb_cj_community_spring_be/post/service/impl/PostServiceImpl.java
@@ -1,6 +1,8 @@
-package com.ktb.ktb_cj_community_spring_be.post.service;
+package com.ktb.ktb_cj_community_spring_be.post.service.impl;
 
-import static com.ktb.ktb_cj_community_spring_be.global.exception.type.ErrorCode.*;
+import static com.ktb.ktb_cj_community_spring_be.global.exception.type.ErrorCode.POST_NOT_FOUND;
+import static com.ktb.ktb_cj_community_spring_be.global.exception.type.ErrorCode.USER_NOT_FOUND;
+import static com.ktb.ktb_cj_community_spring_be.global.exception.type.ErrorCode.WRITE_NOT_YOURSELF;
 
 import com.ktb.ktb_cj_community_spring_be.global.exception.GlobalException;
 import com.ktb.ktb_cj_community_spring_be.global.util.aws.dto.S3ImageDto;
@@ -12,9 +14,13 @@ import com.ktb.ktb_cj_community_spring_be.post.dto.PostRequest;
 import com.ktb.ktb_cj_community_spring_be.post.dto.PostResponse;
 import com.ktb.ktb_cj_community_spring_be.post.entity.Post;
 import com.ktb.ktb_cj_community_spring_be.post.repository.PostRepository;
+import com.ktb.ktb_cj_community_spring_be.post.service.PostService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -131,6 +137,16 @@ public class PostServiceImpl implements PostService {
             imagesList.forEach(post::addImage);
 
             return post;
+      }
+
+      @Override
+      public Page<PostResponse> postList(Pageable pageable) {
+            return postRepository.findAll(pageable).map(PostResponse::fromEntity);
+      }
+
+      @Override
+      public Slice<PostResponse> postListScroll(Pageable pageable) {
+            return null;
       }
 
       private Member getMember(String email) {

--- a/src/main/java/com/ktb/ktb_cj_community_spring_be/post/web/PostController.java
+++ b/src/main/java/com/ktb/ktb_cj_community_spring_be/post/web/PostController.java
@@ -8,6 +8,10 @@ import com.ktb.ktb_cj_community_spring_be.post.service.PostService;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -43,6 +47,16 @@ public class PostController {
       }
 
       /**
+       * 전체 게시물 조회
+       */
+      @GetMapping("/list")
+      public ResponseEntity<Page<PostResponse>> getPostList(
+              @PageableDefault(sort = "createdAt", direction = Direction.DESC) Pageable pageable) {
+
+            return ResponseEntity.ok(postService.postList(pageable));
+      }
+
+      /**
        * 게시물 상세 조회
        */
       @GetMapping("/{id}")
@@ -52,7 +66,6 @@ public class PostController {
 
       /**
        * 게시물 수정
-       *
        */
       @PatchMapping(path = "/{id}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE,
               produces = MediaType.APPLICATION_JSON_VALUE)
@@ -75,5 +88,6 @@ public class PostController {
             postService.deletePost(id, email);
             return ResponseEntity.status(HttpStatus.OK).build();
       }
+
 
 }

--- a/src/main/java/com/ktb/ktb_cj_community_spring_be/post/web/PostLikeController.java
+++ b/src/main/java/com/ktb/ktb_cj_community_spring_be/post/web/PostLikeController.java
@@ -1,0 +1,30 @@
+package com.ktb.ktb_cj_community_spring_be.post.web;
+
+import com.ktb.ktb_cj_community_spring_be.auth.config.LoginUser;
+import com.ktb.ktb_cj_community_spring_be.post.service.PostLikeService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/post")
+@RequiredArgsConstructor
+public class PostLikeController {
+
+      private final PostLikeService postLikeService;
+
+      @PostMapping("/like")
+      public ResponseEntity<?> likePost(@RequestParam("id") Long postId,
+              @LoginUser String email) {
+            return ResponseEntity.ok(postLikeService.likePost(postId, email));
+      }
+
+      @PostMapping("/unlike")
+      public ResponseEntity<?> unlikePost(@RequestParam("id") Long postId,
+              @LoginUser String email) {
+            return ResponseEntity.ok(postLikeService.unlikePost(postId, email));
+      }
+}


### PR DESCRIPTION
### PR 제목
feat: 게시물 좋아요 기능 및 페이징 기능 추가

### 변경사항
<!-- 이 PR에서 어떤 점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요. -->
**AS-IS**
- 게시물에 대한 좋아요 기능이 없었음
- 게시물 조회 시 페이징 기능이 없었음
- 서비스 클래스와 관련 기능들이 단순함

**TO-BE**
- 게시물에 좋아요를 누르는 기능을 추가
- 이미 좋아요가 눌러진 게시물에 대한 예외 처리를 추가
- 특정 게시물의 좋아요 수를 업데이트하는 기능을 추가
- 전체 게시물 조회 시 페이징 기능을 적용
- 사용자의 게시물 좋아요 기능을 추가하여 사용자가 좋아하는 게시물을 표시
- 게시물 전체 리스트 조회 시, 페이징 처리 및 무한 스크롤 기능을 추가
- PostService 관련 클래스의 패키지 위치를 `service.impl`로 변경
- PostLikeService 인터페이스 및 구현체를 생성하여 좋아요 기능을 처리
- PostLikeRepository를 생성하여 데이터베이스와의 상호 작용을 담당
- PostLikeResponse DTO를 생성하여 좋아요 상태 응답을 관리
- MemberService를 생성하여 회원 관련 서비스를 처리
- PostLikeController를 생성하여 좋아요 및 좋아요 취소 요청을 처리

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 -->
- [ ] 테스트 코드 작성
- [ ] 좋아요 및 좋아요 취소 기능 테스트
- [ ] 게시물 조회 및 페이징 기능 테스트