### PR TITLE
feat: 회원 정보 및 비밀번호 업데이트 기능 추가

### DIFF
--- a/src/main/java/com/ktb/ktb_cj_community_spring_be/global/exception/type/ErrorCode.java
+++ b/src/main/java/com/ktb/ktb_cj_community_spring_be/global/exception/type/ErrorCode.java
@@ -24,7 +24,8 @@ public enum ErrorCode {
       POST_IMAGE_UPLOAD_ERROR(HttpStatus.BAD_REQUEST, "게시물 이미지 업로드 중 오류가 발생했습니다."),
       ALREADY_LIKED(HttpStatus.BAD_REQUEST, "이미 좋아요를 누른 게시물입니다."),
       ALREADY_UNLIKED(HttpStatus.BAD_REQUEST, "이미 좋아요를 취소한 게시물입니다."),
-
+      NICKNAME_DUPLICATION(HttpStatus.BAD_REQUEST, "이미 사용중인 닉네임입니다."),
+      PASSWORD_EMPTY(HttpStatus.BAD_REQUEST, "비밀번호를 입력해주세요."),
       /**
        * 401 Unauthorized
        */
@@ -66,7 +67,7 @@ public enum ErrorCode {
       /**
        * 405 Method Not Allowed
        */
-      METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "허용되지 않은 HTTP 메서드입니다.")
+      METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "허용되지 않은 HTTP 메서드입니다."),
       ;
 
       private final HttpStatus httpStatus;

--- a/src/main/java/com/ktb/ktb_cj_community_spring_be/member/dto/MemberResponse.java
+++ b/src/main/java/com/ktb/ktb_cj_community_spring_be/member/dto/MemberResponse.java
@@ -1,0 +1,31 @@
+package com.ktb.ktb_cj_community_spring_be.member.dto;
+
+import com.ktb.ktb_cj_community_spring_be.member.entity.Member;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class MemberResponse {
+
+      private Long memberId;
+      private String memberEmail;
+      private String memberNickname;
+
+      private String memberProfileImageUrl;
+
+      public static MemberResponse fromEntity(Member member) {
+            return MemberResponse.builder()
+                    .memberId(member.getId())
+                    .memberEmail(member.getEmail())
+                    .memberNickname(member.getNickname())
+                    .memberProfileImageUrl(member.getProfileImageUrl())
+                    .build();
+      }
+}

--- a/src/main/java/com/ktb/ktb_cj_community_spring_be/member/dto/UpdateMemberInfoRequest.java
+++ b/src/main/java/com/ktb/ktb_cj_community_spring_be/member/dto/UpdateMemberInfoRequest.java
@@ -1,0 +1,31 @@
+package com.ktb.ktb_cj_community_spring_be.member.dto;
+
+import com.ktb.ktb_cj_community_spring_be.member.entity.Member;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UpdateMemberInfoRequest {
+
+      @Email
+      private String email;
+      @NotBlank
+      private String nickName;
+
+      private String profileImageUrl;
+
+      public void updateMemberInfoToEntity(Member member, String profileImageUrl) {
+            member.setNickname(this.nickName);
+            member.setProfileImageUrl(profileImageUrl);
+      }
+
+}

--- a/src/main/java/com/ktb/ktb_cj_community_spring_be/member/dto/UpdateMemberPwdRequest.java
+++ b/src/main/java/com/ktb/ktb_cj_community_spring_be/member/dto/UpdateMemberPwdRequest.java
@@ -1,0 +1,24 @@
+package com.ktb.ktb_cj_community_spring_be.member.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UpdateMemberPwdRequest {
+
+      @NotBlank
+      private String newPassword;
+
+      @NotNull
+      private String validationPassword;
+
+}

--- a/src/main/java/com/ktb/ktb_cj_community_spring_be/member/repository/MemberRepository.java
+++ b/src/main/java/com/ktb/ktb_cj_community_spring_be/member/repository/MemberRepository.java
@@ -12,4 +12,5 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
       boolean existsByEmail(String email);
 
+      boolean existsByNickName(String nickName);
 }

--- a/src/main/java/com/ktb/ktb_cj_community_spring_be/member/service/MemberService.java
+++ b/src/main/java/com/ktb/ktb_cj_community_spring_be/member/service/MemberService.java
@@ -1,5 +1,18 @@
 package com.ktb.ktb_cj_community_spring_be.member.service;
 
-public class MemberService {
+import com.ktb.ktb_cj_community_spring_be.member.dto.MemberResponse;
+import com.ktb.ktb_cj_community_spring_be.member.dto.UpdateMemberInfoRequest;
+import com.ktb.ktb_cj_community_spring_be.member.dto.UpdateMemberPwdRequest;
+import org.springframework.web.multipart.MultipartFile;
 
+public interface MemberService {
+
+      MemberResponse memberInfo(String email);
+
+      MemberResponse updateMemberNickName(UpdateMemberInfoRequest request,
+              MultipartFile profileImage, String email);
+
+      MemberResponse updateMemberPassword(UpdateMemberPwdRequest request, String email);
+
+      boolean checkNickNameDuplication(String nickName);
 }

--- a/src/main/java/com/ktb/ktb_cj_community_spring_be/member/service/impl/MemberServiceImpl.java
+++ b/src/main/java/com/ktb/ktb_cj_community_spring_be/member/service/impl/MemberServiceImpl.java
@@ -1,0 +1,125 @@
+package com.ktb.ktb_cj_community_spring_be.member.service.impl;
+
+
+import static com.ktb.ktb_cj_community_spring_be.global.exception.type.ErrorCode.PROFILE_IMAGE_UPLOAD_ERROR;
+import static com.ktb.ktb_cj_community_spring_be.global.exception.type.ErrorCode.USER_NOT_FOUND;
+
+import com.ktb.ktb_cj_community_spring_be.global.exception.GlobalException;
+import com.ktb.ktb_cj_community_spring_be.global.exception.type.ErrorCode;
+import com.ktb.ktb_cj_community_spring_be.global.util.aws.service.AwsS3Service;
+import com.ktb.ktb_cj_community_spring_be.member.dto.MemberResponse;
+import com.ktb.ktb_cj_community_spring_be.member.dto.UpdateMemberInfoRequest;
+import com.ktb.ktb_cj_community_spring_be.member.dto.UpdateMemberPwdRequest;
+import com.ktb.ktb_cj_community_spring_be.member.entity.Member;
+import com.ktb.ktb_cj_community_spring_be.member.repository.MemberRepository;
+import com.ktb.ktb_cj_community_spring_be.member.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MemberServiceImpl implements MemberService {
+
+      private final MemberRepository memberRepository;
+      private final AwsS3Service awsS3Service;
+      private final PasswordEncoder passwordEncoder;
+
+      @Transactional(readOnly = true)
+      @Override
+      public MemberResponse memberInfo(String email) {
+
+            Member member = getMember(email);
+
+            return MemberResponse.fromEntity(member);
+      }
+
+      @Transactional
+      @Override
+      public MemberResponse updateMemberNickName(UpdateMemberInfoRequest request,
+              MultipartFile profileImage, String email) {
+            Member member = getMember(email);
+
+            String profileImageUrl = member.getProfileImageUrl();
+
+            // 닉네임 중복 더블 체크
+            if (checkNickNameDuplication(request.getNickName())) {
+                  throw new GlobalException(ErrorCode.NICKNAME_DUPLICATION);
+            }
+
+            if (profileImage != null && !profileImage.isEmpty()) {
+                  // 기존 이미지가 있다면 삭제
+                  if (profileImageUrl != null && !profileImageUrl.isEmpty()) {
+                        awsS3Service.deleteFilesUsingUrl(profileImageUrl);
+                  }
+                  try {
+                        profileImageUrl = uploadProfileImage(profileImage);
+                  } catch (Exception e) { // 이미지 업로드 중 오류 발생 시 예외 처리
+                        throw new GlobalException(PROFILE_IMAGE_UPLOAD_ERROR);
+                  }
+            }
+
+            // request 로 부터 값을 받아와 member 객체의 상태 변경
+            request.updateMemberInfoToEntity(member, profileImageUrl);
+
+            return MemberResponse.fromEntity(member);
+      }
+
+      /**
+       * 닉네임 중복 조회
+       *
+       * @param nickName 닉네임 정보
+       * @return 중복이 없을 경우 true
+       * @throws GlobalException 닉네임 중복 시 예외 발생
+       */
+      // 멤버 닉네임 중복 조회
+      @Override
+      public boolean checkNickNameDuplication(String nickName) {
+            return memberRepository.existsByNickName(nickName);
+      }
+
+
+      /**
+       * 비밀번호 변경
+       *
+       * @param request 비밀번호 변경 요청
+       * @param email   멤버 이메일
+       * @return 변경된 멤버 정보
+       */
+
+      @Transactional
+      @Override
+      public MemberResponse updateMemberPassword(UpdateMemberPwdRequest request, String email) {
+
+            Member member = getMember(email);
+
+            if (request.getNewPassword() == null || request.getNewPassword().isEmpty()) {
+                  throw new GlobalException(ErrorCode.PASSWORD_EMPTY);
+            }
+
+            String encodedPasswordEncoder = passwordEncoder.encode(request.getNewPassword());
+
+            member.setPassword(encodedPasswordEncoder);
+
+            return MemberResponse.fromEntity(member);
+      }
+
+
+      private Member getMember(String email) {
+            return memberRepository.findByEmail(email).orElseThrow(()
+                    -> new GlobalException(USER_NOT_FOUND));
+      }
+
+      private String uploadProfileImage(MultipartFile multipartFile) {
+            String filName = awsS3Service.generateFileName(multipartFile);
+            awsS3Service.uploadToS3(multipartFile, filName);
+
+            return awsS3Service.getUrl(filName);
+      }
+
+
+}

--- a/src/main/java/com/ktb/ktb_cj_community_spring_be/member/web/MemberController.java
+++ b/src/main/java/com/ktb/ktb_cj_community_spring_be/member/web/MemberController.java
@@ -1,0 +1,53 @@
+package com.ktb.ktb_cj_community_spring_be.member.web;
+
+import com.ktb.ktb_cj_community_spring_be.auth.config.LoginUser;
+import com.ktb.ktb_cj_community_spring_be.member.dto.MemberResponse;
+import com.ktb.ktb_cj_community_spring_be.member.dto.UpdateMemberInfoRequest;
+import com.ktb.ktb_cj_community_spring_be.member.dto.UpdateMemberPwdRequest;
+import com.ktb.ktb_cj_community_spring_be.member.service.MemberService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequestMapping("/api/member")
+@RequiredArgsConstructor
+public class MemberController {
+
+      private final MemberService memberService;
+
+      @GetMapping("/myProfile")
+      public ResponseEntity<MemberResponse> getMyProfile(@LoginUser String email) {
+            return ResponseEntity.ok(memberService.memberInfo(email));
+      }
+
+      @PostMapping("/nicknameValidation")
+      public ResponseEntity<Boolean> nicknameValidation(String nickname) {
+            return ResponseEntity.ok(memberService.checkNickNameDuplication(nickname));
+      }
+
+      @PatchMapping("/myProfile/update")
+      public ResponseEntity<MemberResponse> updateMyProfile(
+              @RequestPart(value = "request") UpdateMemberInfoRequest request,
+              @RequestPart(value = "profileImage", required = false) MultipartFile profileImage,
+              @LoginUser String email) {
+            return ResponseEntity.ok(
+                    memberService.updateMemberNickName(request, profileImage, email));
+      }
+
+      @PatchMapping("/myProfile/update/password")
+      public ResponseEntity<MemberResponse> updateMyPassword(
+              @Valid @RequestBody UpdateMemberPwdRequest request,
+              @LoginUser String email) {
+            return ResponseEntity.ok(
+                    memberService.updateMemberPassword(request, email));
+      }
+}


### PR DESCRIPTION

### 변경사항
<!-- 이 PR에서 어떤 점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요. -->
**AS-IS**
- 회원 프로필 정보 업데이트 기능이 없었음
- 회원 비밀번호 변경 기능이 없었음
- 닉네임 중복 체크 기능이 없었음
- AWS S3를 사용한 프로필 이미지 업로드 기능이 없었음

**TO-BE**
- 회원 프로필 정보(이메일, 닉네임, 프로필 이미지) 업데이트 기능 추가
- 회원 비밀번호 변경 기능 추가
- 닉네임 중복 체크 기능 추가
- AWS S3를 사용하여 프로필 이미지 업로드 기능 추가

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 -->


