### PR TITLE
feat: 댓글 및 게시물 관련 기능 추가

### DIFF
--- a/src/main/generated/com/ktb/ktb_cj_community_spring_be/comment/entity/QComment.java
+++ b/src/main/generated/com/ktb/ktb_cj_community_spring_be/comment/entity/QComment.java
@@ -20,11 +20,13 @@ public class QComment extends EntityPathBase<Comment> {
 
     private static final PathInits INITS = PathInits.DIRECT2;
 
-    public static final QComment comment1 = new QComment("comment1");
+    public static final QComment comment = new QComment("comment");
 
     public final com.ktb.ktb_cj_community_spring_be.global.entity.QBaseEntity _super = new com.ktb.ktb_cj_community_spring_be.global.entity.QBaseEntity(this);
 
-    public final StringPath comment = createString("comment");
+    public final ListPath<CommentLike, QCommentLike> commentLikes = this.<CommentLike, QCommentLike>createList("commentLikes", CommentLike.class, QCommentLike.class, PathInits.DIRECT2);
+
+    public final StringPath content = createString("content");
 
     //inherited
     public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;

--- a/src/main/java/com/ktb/ktb_cj_community_spring_be/comment/dto/CommentRequest.java
+++ b/src/main/java/com/ktb/ktb_cj_community_spring_be/comment/dto/CommentRequest.java
@@ -1,0 +1,31 @@
+package com.ktb.ktb_cj_community_spring_be.comment.dto;
+
+
+import com.ktb.ktb_cj_community_spring_be.comment.entity.Comment;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CommentRequest {
+
+      @NotBlank(message = "게시물 Id는 필수입니다.")
+      private Long postId;
+
+      @NotBlank(message = "내용은 필수입니다.")
+      private String content;
+
+
+      public Comment toEntity(CommentRequest request) {
+            return Comment.builder()
+                    .content(request.getContent())
+                    .build();
+      }
+}

--- a/src/main/java/com/ktb/ktb_cj_community_spring_be/comment/dto/CommentResponse.java
+++ b/src/main/java/com/ktb/ktb_cj_community_spring_be/comment/dto/CommentResponse.java
@@ -1,0 +1,42 @@
+package com.ktb.ktb_cj_community_spring_be.comment.dto;
+
+import com.ktb.ktb_cj_community_spring_be.comment.entity.Comment;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CommentResponse {
+
+      Long memberId;
+      Long postId;
+      Long commentId;
+
+      String memberEmail;
+      String memberNickname;
+      String content;
+
+      LocalDateTime createdAt;
+      LocalDateTime updatedAt;
+
+      public static CommentResponse fromEntity(Comment comment) {
+            return CommentResponse.builder()
+                    .memberId(comment.getMember().getId())
+                    .postId(comment.getPost().getId())
+                    .commentId(comment.getId())
+                    .memberEmail(comment.getMember().getEmail())
+                    .memberNickname(comment.getMember().getNickname())
+                    .content(comment.getContent())
+                    .createdAt(comment.getCreatedAt())
+                    .updatedAt(comment.getUpdatedAt())
+                    .build();
+      }
+
+}

--- a/src/main/java/com/ktb/ktb_cj_community_spring_be/comment/entity/Comment.java
+++ b/src/main/java/com/ktb/ktb_cj_community_spring_be/comment/entity/Comment.java
@@ -3,10 +3,16 @@ package com.ktb.ktb_cj_community_spring_be.comment.entity;
 import com.ktb.ktb_cj_community_spring_be.global.entity.BaseEntity;
 import com.ktb.ktb_cj_community_spring_be.member.entity.Member;
 import com.ktb.ktb_cj_community_spring_be.post.entity.Post;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
-import jakarta.persistence.*;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -24,7 +30,7 @@ import lombok.Setter;
 public class Comment extends BaseEntity {
 
       @Id
-      @GeneratedValue(strategy =  GenerationType.IDENTITY)
+      @GeneratedValue(strategy = GenerationType.IDENTITY)
       private Long id;
 
       @ManyToOne(fetch = FetchType.LAZY)
@@ -36,9 +42,35 @@ public class Comment extends BaseEntity {
       private Member member;
 
       @Column(nullable = false)
-      private String comment;
+      private String content;
 
       @Column(nullable = false)
       private int likeCount;
+
+      @OneToMany(mappedBy = "comment", fetch = FetchType.LAZY, orphanRemoval = true)
+      private List<CommentLike> commentLikes;
+
+      public void addPostAndMember(Post post, Member member) {
+            this.post = post;
+            this.member = member;
+
+            post.addComment(this);
+      }
+
+      public void changeContent(String content) {
+            this.content = content;
+      }
+
+      public void addCommentLike(CommentLike commentLike) {
+            this.commentLikes.add(commentLike);
+      }
+
+      public void updateLikeCount() {
+            this.likeCount = this.commentLikes.size();
+      }
+
+      public void removeCommentLike(CommentLike commentLike) {
+            this.commentLikes.remove(commentLike);
+      }
 
 }

--- a/src/main/java/com/ktb/ktb_cj_community_spring_be/comment/repository/CommentRepository.java
+++ b/src/main/java/com/ktb/ktb_cj_community_spring_be/comment/repository/CommentRepository.java
@@ -1,0 +1,10 @@
+package com.ktb.ktb_cj_community_spring_be.comment.repository;
+
+import com.ktb.ktb_cj_community_spring_be.comment.entity.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CommentRepository extends JpaRepository<Comment, Long>, CustomCommentRepository {
+
+}

--- a/src/main/java/com/ktb/ktb_cj_community_spring_be/comment/repository/CustomCommentRepository.java
+++ b/src/main/java/com/ktb/ktb_cj_community_spring_be/comment/repository/CustomCommentRepository.java
@@ -1,0 +1,11 @@
+package com.ktb.ktb_cj_community_spring_be.comment.repository;
+
+import com.ktb.ktb_cj_community_spring_be.comment.entity.Comment;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+
+public interface CustomCommentRepository {
+
+      Slice<Comment> findCommentsByPost(Long postId, Long commentId, Pageable pageable);
+
+}

--- a/src/main/java/com/ktb/ktb_cj_community_spring_be/comment/repository/impl/CustomCommentRepositoryImpl.java
+++ b/src/main/java/com/ktb/ktb_cj_community_spring_be/comment/repository/impl/CustomCommentRepositoryImpl.java
@@ -1,0 +1,56 @@
+package com.ktb.ktb_cj_community_spring_be.comment.repository.impl;
+
+import static com.ktb.ktb_cj_community_spring_be.comment.entity.QComment.comment;
+
+import com.ktb.ktb_cj_community_spring_be.comment.entity.Comment;
+import com.ktb.ktb_cj_community_spring_be.comment.repository.CustomCommentRepository;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+
+@RequiredArgsConstructor
+@Slf4j
+public class CustomCommentRepositoryImpl implements CustomCommentRepository {
+
+      private final JPAQueryFactory jpa;
+      private final EntityManager entityManager;
+
+      @Override
+      public Slice<Comment> findCommentsByPost(Long postId, Long commentId, Pageable pageable) {
+            List<Comment> commentList = jpa
+                    .selectFrom(comment)
+                    .where(ltCommentId(commentId),
+                            comment.post.id.eq(postId))
+                    .orderBy(comment.id.desc())
+                    .limit(pageable.getPageSize() + 1)
+                    .fetch();
+
+            return checkLastComment(pageable, commentList);
+      }
+
+      private BooleanExpression ltCommentId(Long commentId) {
+            if (commentId == null || commentId == 0L) {
+                  return null;
+            }
+
+            return comment.id.lt(commentId);
+      }
+
+      private Slice<Comment> checkLastComment(Pageable pageable, List<Comment> results) {
+
+            boolean hasNext = false;
+
+            if (results.size() > pageable.getPageSize()) {
+                  hasNext = true;
+                  results.remove(pageable.getPageSize());
+            }
+
+            return new SliceImpl<>(results, pageable, hasNext);
+      }
+}

--- a/src/main/java/com/ktb/ktb_cj_community_spring_be/comment/service/CommentService.java
+++ b/src/main/java/com/ktb/ktb_cj_community_spring_be/comment/service/CommentService.java
@@ -1,0 +1,17 @@
+package com.ktb.ktb_cj_community_spring_be.comment.service;
+
+import com.ktb.ktb_cj_community_spring_be.comment.dto.CommentRequest;
+import com.ktb.ktb_cj_community_spring_be.comment.dto.CommentResponse;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+
+public interface CommentService {
+
+      CommentResponse createComment(CommentRequest request, String email);
+
+      CommentResponse updateComment(CommentRequest request, Long commentId, String email);
+
+      void deleteComment(Long commentId, String email);
+
+      Slice<CommentResponse> getComments(Long postId, Long commentId, Pageable pageable);
+}

--- a/src/main/java/com/ktb/ktb_cj_community_spring_be/comment/service/impl/CommentServiceImpl.java
+++ b/src/main/java/com/ktb/ktb_cj_community_spring_be/comment/service/impl/CommentServiceImpl.java
@@ -1,0 +1,98 @@
+package com.ktb.ktb_cj_community_spring_be.comment.service.impl;
+
+import static com.ktb.ktb_cj_community_spring_be.global.exception.type.ErrorCode.COMMENT_NOT_FOUND;
+import static com.ktb.ktb_cj_community_spring_be.global.exception.type.ErrorCode.POST_NOT_FOUND;
+import static com.ktb.ktb_cj_community_spring_be.global.exception.type.ErrorCode.USER_NOT_FOUND;
+import static com.ktb.ktb_cj_community_spring_be.global.exception.type.ErrorCode.WRITE_NOT_YOURSELF;
+
+import com.ktb.ktb_cj_community_spring_be.comment.dto.CommentRequest;
+import com.ktb.ktb_cj_community_spring_be.comment.dto.CommentResponse;
+import com.ktb.ktb_cj_community_spring_be.comment.entity.Comment;
+import com.ktb.ktb_cj_community_spring_be.comment.repository.CommentRepository;
+import com.ktb.ktb_cj_community_spring_be.comment.service.CommentService;
+import com.ktb.ktb_cj_community_spring_be.global.exception.GlobalException;
+import com.ktb.ktb_cj_community_spring_be.member.entity.Member;
+import com.ktb.ktb_cj_community_spring_be.member.repository.MemberRepository;
+import com.ktb.ktb_cj_community_spring_be.post.entity.Post;
+import com.ktb.ktb_cj_community_spring_be.post.repository.PostRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CommentServiceImpl implements CommentService {
+
+      private final CommentRepository commentRepository;
+      private final MemberRepository memberRepository;
+      private final PostRepository postRepository;
+
+      @Override
+      public CommentResponse createComment(CommentRequest request, String email) {
+            Member member = getMember(email);
+            Post post = getPost(request.getPostId());
+
+            Comment comment = request.toEntity(request);
+
+            comment.addPostAndMember(post, member);
+
+            return CommentResponse.fromEntity(commentRepository.save(comment));
+      }
+
+
+      @Override
+      @Transactional
+      public CommentResponse updateComment(CommentRequest request, Long commentId, String email) {
+            postRepository.findById(request.getPostId())
+                    .orElseThrow(() -> new GlobalException(POST_NOT_FOUND));
+
+            Comment comment = getComment(commentId);
+
+            validationComment(comment, email);
+
+            comment.changeContent(request.getContent());
+
+            return CommentResponse.fromEntity(comment);
+      }
+
+
+      @Override
+      @Transactional
+      public void deleteComment(Long commentId, String email) {
+            Comment comment = getComment(commentId);
+            validationComment(comment, email);
+            commentRepository.delete(comment);
+      }
+
+      @Override
+      public Slice<CommentResponse> getComments(Long postId, Long commentId, Pageable pageable) {
+            return commentRepository.findCommentsByPost(postId, commentId, pageable)
+                    .map(CommentResponse::fromEntity);
+      }
+
+      private Comment getComment(Long commentId) {
+            return commentRepository.findById(commentId)
+                    .orElseThrow(() -> new GlobalException(COMMENT_NOT_FOUND));
+      }
+
+      private Post getPost(Long postId) {
+            return postRepository.findById(postId)
+                    .orElseThrow(() -> new GlobalException(POST_NOT_FOUND));
+      }
+
+      private Member getMember(String email) {
+            return memberRepository.findByEmail(email)
+                    .orElseThrow(() -> new GlobalException(USER_NOT_FOUND));
+      }
+
+      private void validationComment(Comment comment, String email) {
+            if (!comment.getMember().getEmail().equals(email)) {
+                  throw new GlobalException(WRITE_NOT_YOURSELF);
+            }
+      }
+
+}

--- a/src/main/java/com/ktb/ktb_cj_community_spring_be/comment/web/CommentController.java
+++ b/src/main/java/com/ktb/ktb_cj_community_spring_be/comment/web/CommentController.java
@@ -1,0 +1,72 @@
+package com.ktb.ktb_cj_community_spring_be.comment.web;
+
+import com.ktb.ktb_cj_community_spring_be.auth.config.LoginUser;
+import com.ktb.ktb_cj_community_spring_be.comment.dto.CommentRequest;
+import com.ktb.ktb_cj_community_spring_be.comment.dto.CommentResponse;
+import com.ktb.ktb_cj_community_spring_be.comment.service.CommentService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("api/comment")
+@RequiredArgsConstructor
+public class CommentController {
+
+      private final CommentService commentService;
+
+      /**
+       * 해당 게시물 댓글 목록 조회
+       */
+      @GetMapping("/{postId}")
+      public ResponseEntity<?> getCommentList(@PathVariable("postId") Long postId,
+              @RequestParam(value = "commentId", required = false) Long commentId,
+              @PageableDefault(sort = "id", direction = Direction.DESC) Pageable pageable) {
+
+            return ResponseEntity.ok(commentService.getComments(postId, commentId, pageable));
+      }
+
+      /**
+       * 댓글 생성
+       */
+      @PostMapping
+      public ResponseEntity<CommentResponse> createComment(@RequestBody CommentRequest request,
+              @LoginUser String email) {
+            return ResponseEntity.status(HttpStatus.CREATED)
+                    .body(commentService.createComment(request, email));
+      }
+
+      /**
+       * 댓글 수정
+       */
+      @PatchMapping
+      public ResponseEntity<CommentResponse> updateComment(@RequestBody CommentRequest request,
+              @Valid @RequestParam("commentId") Long commentId, @LoginUser String email) {
+            return ResponseEntity.ok(commentService.updateComment(request, commentId, email));
+      }
+
+      /**
+       * 댓글 삭제
+       */
+      @DeleteMapping
+      public ResponseEntity<?> deleteComment(@RequestParam("id") Long commentId,
+              @LoginUser String email) {
+            commentService.deleteComment(commentId, email);
+            return ResponseEntity.noContent().build();
+      }
+
+
+}

--- a/src/main/java/com/ktb/ktb_cj_community_spring_be/global/service/RedisService.java
+++ b/src/main/java/com/ktb/ktb_cj_community_spring_be/global/service/RedisService.java
@@ -1,6 +1,7 @@
 package com.ktb.ktb_cj_community_spring_be.global.service;
 
 import java.time.Duration;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -65,5 +66,17 @@ public class RedisService {
             } catch (Exception e) {
                   log.error("Error occurred while deleting key : {}", key, e);
             }
+      }
+
+      public void increaseHashData(String hashKey, String key) {
+            redisTemplate.opsForHash().increment(hashKey, key, 1);
+      }
+
+      public Map<Object, Object> hasHashKeys(String key) {
+            return redisTemplate.opsForHash().entries(key);
+      }
+
+      public void deleteHashKey(String hashKey, String key) {
+            redisTemplate.opsForHash().delete(hashKey, key);
       }
 }

--- a/src/main/java/com/ktb/ktb_cj_community_spring_be/post/dto/PostResponse.java
+++ b/src/main/java/com/ktb/ktb_cj_community_spring_be/post/dto/PostResponse.java
@@ -1,6 +1,7 @@
 package com.ktb.ktb_cj_community_spring_be.post.dto;
 
 
+import com.ktb.ktb_cj_community_spring_be.comment.dto.CommentResponse;
 import com.ktb.ktb_cj_community_spring_be.global.util.aws.dto.S3ImageDto;
 import com.ktb.ktb_cj_community_spring_be.post.entity.Post;
 import java.time.LocalDateTime;
@@ -10,6 +11,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.springframework.data.domain.Slice;
 
 @Getter
 @Setter
@@ -26,10 +28,17 @@ public class PostResponse {
       private String content;
       private List<S3ImageDto> images;
 
+      private int hits;
+      private int likeCount;
+      private int commentCount;
+
       private LocalDateTime createdAt;
       private LocalDateTime updatedAt;
 
+      private Slice<CommentResponse> comments;
 
+
+      //게시물 상세 조회
       public static PostResponse fromEntity(Post post) {
             List<S3ImageDto> imageList = post.getImages().stream()
                     .map(S3ImageDto::fromEntity).toList();
@@ -41,6 +50,21 @@ public class PostResponse {
                     .title(post.getTitle())
                     .content(post.getContent())
                     .images(imageList)
+                    .hits(post.getHits())
+                    .likeCount(post.getLikeCount())
+                    .commentCount(post.getComments().size())
+                    .createdAt(post.getCreatedAt())
+                    .updatedAt(post.getUpdatedAt())
+                    .build();
+      }
+
+      public static PostResponse listFromEntity(Post post) {
+            return PostResponse.builder()
+                    .id(post.getId())
+                    .memberId(post.getMember().getId())
+                    .memberEmail(post.getMember().getEmail())
+                    .title(post.getTitle())
+                    .content(post.getContent())
                     .createdAt(post.getCreatedAt())
                     .updatedAt(post.getUpdatedAt())
                     .build();

--- a/src/main/java/com/ktb/ktb_cj_community_spring_be/post/entity/Post.java
+++ b/src/main/java/com/ktb/ktb_cj_community_spring_be/post/entity/Post.java
@@ -81,4 +81,8 @@ public class Post extends BaseEntity {
       public void updateLikeCount() {
             this.likeCount = this.postLikes.size();
       }
+
+      public void addComment(Comment comment) {
+            this.comments.add(comment);
+      }
 }

--- a/src/main/java/com/ktb/ktb_cj_community_spring_be/post/repository/CustomPostRepository.java
+++ b/src/main/java/com/ktb/ktb_cj_community_spring_be/post/repository/CustomPostRepository.java
@@ -11,4 +11,6 @@ public interface CustomPostRepository {
 
       @Transactional
       void updateViews(Long postId, int hits);
+
+      Slice<Post> findAllPosts(Long postId, Pageable pageable);
 }

--- a/src/main/java/com/ktb/ktb_cj_community_spring_be/post/repository/PostRepository.java
+++ b/src/main/java/com/ktb/ktb_cj_community_spring_be/post/repository/PostRepository.java
@@ -6,6 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface PostRepository extends JpaRepository<Post, Long> {
+public interface PostRepository extends JpaRepository<Post, Long>, CustomPostRepository {
 
 }

--- a/src/main/java/com/ktb/ktb_cj_community_spring_be/post/repository/impl/CustomPostRepositoryImpl.java
+++ b/src/main/java/com/ktb/ktb_cj_community_spring_be/post/repository/impl/CustomPostRepositoryImpl.java
@@ -56,6 +56,13 @@ public class CustomPostRepositoryImpl implements CustomPostRepository {
             return post.id.lt(postId);
       }
 
+      /**
+       * 무한 스크롤을 위한 게시물 조회
+       *
+       * @param postId   마지막 게시물의 id
+       * @param pageable 페이지 정보
+       * @return 조회된 게시물 리스트
+       */
       public Slice<Post> findAllPosts(Long postId, Pageable pageable) {
             List<Post> postList = jpa
                     .selectFrom(post)

--- a/src/main/java/com/ktb/ktb_cj_community_spring_be/post/service/PostService.java
+++ b/src/main/java/com/ktb/ktb_cj_community_spring_be/post/service/PostService.java
@@ -3,6 +3,7 @@ package com.ktb.ktb_cj_community_spring_be.post.service;
 import com.ktb.ktb_cj_community_spring_be.post.dto.PostRequest;
 import com.ktb.ktb_cj_community_spring_be.post.dto.PostResponse;
 import com.ktb.ktb_cj_community_spring_be.post.entity.Post;
+import jakarta.servlet.http.HttpServletRequest;
 import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -14,7 +15,7 @@ public interface PostService {
 
       PostResponse createPost(PostRequest request, List<MultipartFile> images, String email);
 
-      PostResponse readPost(Long postId);
+      PostResponse readPost(Long postId, HttpServletRequest request);
 
       PostResponse updatePost(Long id, PostRequest request, List<MultipartFile> newImages,
               List<Long> imageIdsToDelete, String email);
@@ -22,6 +23,7 @@ public interface PostService {
       void deletePost(Long id, String email);
 
       Post uploadS3Image(PostRequest request, List<MultipartFile> multipartFiles);
+
 
       // 게시물 전체 리스트 - 페이징 처리
       Page<PostResponse> postList(Pageable pageable);

--- a/src/main/java/com/ktb/ktb_cj_community_spring_be/post/web/PostController.java
+++ b/src/main/java/com/ktb/ktb_cj_community_spring_be/post/web/PostController.java
@@ -5,6 +5,7 @@ import com.ktb.ktb_cj_community_spring_be.auth.config.LoginUser;
 import com.ktb.ktb_cj_community_spring_be.post.dto.PostRequest;
 import com.ktb.ktb_cj_community_spring_be.post.dto.PostResponse;
 import com.ktb.ktb_cj_community_spring_be.post.service.PostService;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -59,9 +60,10 @@ public class PostController {
       /**
        * 게시물 상세 조회
        */
-      @GetMapping("/{id}")
-      public ResponseEntity<PostResponse> getPostDetail(@PathVariable Long id) {
-            return ResponseEntity.ok(postService.readPost(id));
+      @GetMapping("/detail/{id}")
+      public ResponseEntity<PostResponse> getPostDetail(@PathVariable Long id,
+              HttpServletRequest request) {
+            return ResponseEntity.ok(postService.readPost(id, request));
       }
 
       /**


### PR DESCRIPTION


### 변경사항
<!-- 이 PR에서 어떤 점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요. -->
**AS-IS**
- 댓글 기능이 없었음
- 게시물 목록 조회 시 무한 스크롤 기능이 없었음
- 게시물 조회수 카운트 로직이 없었음
- 댓글 엔티티에 내용 필드 및 연관관계 설정이 없었음
- Redis를 사용한 조회수 관리 기능이 없었음

**TO-BE**
- 댓글 생성, 수정, 삭제, 조회 등의 API를 처리하는 기능 추가
- 댓글은 회원, 게시글과 관계를 가지며, JPA를 이용해 데이터 처리
- 게시물 목록을 무한 스크롤로 조회할 수 있도록 메서드 추가
- 중복 조회를 방지하고 조회수를 카운트하는 로직 추가
- 댓글 엔티티에 내용 필드 및 연관관계 설정 추가
- Redis 서비스에 해시 데이터 관련 메서드 추가

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 -->


#### 주요 변경사항
- `CommentRepository`, `CommentService`, `CommentController` 및 관련 DTO, 엔티티 추가
- 게시물 목록 조회 시 무한 스크롤 기능 추가
- 조회수 카운트 로직 및 Redis를 활용한 조회수 관리 기능 추가
- 댓글 엔티티에 내용 필드 및 연관관계 설정 추가

